### PR TITLE
Changed text from "Private" to "Privacy" on cookie banner

### DIFF
--- a/public/static/locales/en/common.json
+++ b/public/static/locales/en/common.json
@@ -16,7 +16,7 @@
   "email": "Email",
   "cookies": {
     "allowTrack": "Allow tracking of my activity on <0>celo.org</0> to help improve this website.",
-    "understandMore": "Understand more in our <0>Private Policy.</0>",
+    "understandMore": "Understand more in our <0>Privacy Policy.</0>",
     "cookiesDisagree": "No",
     "cookiesAgree": "Yes"
   },


### PR DESCRIPTION
_**New Text Update**_
<img width="1129" alt="Screen Shot 2021-03-01 at 12 34 45 PM" src="https://user-images.githubusercontent.com/55670305/109535833-005bef80-7a8b-11eb-8fea-f725f793160c.png">
