### PR TITLE
show events even if top event or upcomming missing (but not both)

### DIFF
--- a/src/community/connect/EventsData.tsx
+++ b/src/community/connect/EventsData.tsx
@@ -16,8 +16,11 @@ export default class EventData extends React.PureComponent {
 
   componentDidMount = async () => {
     const { upcomingEvents, topEvent } = await getEvents("upcoming=true")
-    if (upcomingEvents && topEvent) {
+    if (upcomingEvents || topEvent) {
       this.setState({ upcomingEvents, topEvent, loaded: true })
+    } else {
+      this.setState({ loaded: true })
+      console.error("events missing")
     }
   }
 


### PR DESCRIPTION
events were stuck on loading bc top event was missing. 

now will at least show the events that are there. 