### PR TITLE
Removed the underline decoration from the navbar kit title. 

### DIFF
--- a/src/_page-tests/experience/__snapshots__/color.test.tsx.snap
+++ b/src/_page-tests/experience/__snapshots__/color.test.tsx.snap
@@ -159,6 +159,15 @@ exports[`Experience/Color renders 1`] = `
               </div>
             </a>
             <a
+              css={
+                Object {
+                  "map": undefined,
+                  "name": "ytumd6",
+                  "next": undefined,
+                  "styles": "text-decoration:none;",
+                  "toString": [Function],
+                }
+              }
               href="/experience/brand"
             >
               <div

--- a/src/_page-tests/experience/__snapshots__/composition.test.tsx.snap
+++ b/src/_page-tests/experience/__snapshots__/composition.test.tsx.snap
@@ -159,6 +159,15 @@ exports[`Experience/Composition renders 1`] = `
               </div>
             </a>
             <a
+              css={
+                Object {
+                  "map": undefined,
+                  "name": "ytumd6",
+                  "next": undefined,
+                  "styles": "text-decoration:none;",
+                  "toString": [Function],
+                }
+              }
               href="/experience/brand"
             >
               <div

--- a/src/_page-tests/experience/__snapshots__/exchange-icons.test.tsx.snap
+++ b/src/_page-tests/experience/__snapshots__/exchange-icons.test.tsx.snap
@@ -159,6 +159,15 @@ exports[`Experience/ExchangeIcons renders 1`] = `
               </div>
             </a>
             <a
+              css={
+                Object {
+                  "map": undefined,
+                  "name": "ytumd6",
+                  "next": undefined,
+                  "styles": "text-decoration:none;",
+                  "toString": [Function],
+                }
+              }
               href="/experience/brand"
             >
               <div

--- a/src/_page-tests/experience/__snapshots__/icons.test.tsx.snap
+++ b/src/_page-tests/experience/__snapshots__/icons.test.tsx.snap
@@ -159,6 +159,15 @@ exports[`Experience/Icons renders 1`] = `
               </div>
             </a>
             <a
+              css={
+                Object {
+                  "map": undefined,
+                  "name": "ytumd6",
+                  "next": undefined,
+                  "styles": "text-decoration:none;",
+                  "toString": [Function],
+                }
+              }
               href="/experience/brand"
             >
               <div

--- a/src/_page-tests/experience/__snapshots__/index.test.tsx.snap
+++ b/src/_page-tests/experience/__snapshots__/index.test.tsx.snap
@@ -159,6 +159,15 @@ exports[`Experience/Brandkit renders 1`] = `
               </div>
             </a>
             <a
+              css={
+                Object {
+                  "map": undefined,
+                  "name": "ytumd6",
+                  "next": undefined,
+                  "styles": "text-decoration:none;",
+                  "toString": [Function],
+                }
+              }
               href="/experience/brand"
             >
               <div

--- a/src/_page-tests/experience/__snapshots__/key-imagery.test.tsx.snap
+++ b/src/_page-tests/experience/__snapshots__/key-imagery.test.tsx.snap
@@ -159,6 +159,15 @@ exports[`Experience/KeyImagery renders 1`] = `
               </div>
             </a>
             <a
+              css={
+                Object {
+                  "map": undefined,
+                  "name": "ytumd6",
+                  "next": undefined,
+                  "styles": "text-decoration:none;",
+                  "toString": [Function],
+                }
+              }
               href="/experience/brand"
             >
               <div

--- a/src/_page-tests/experience/__snapshots__/logo.test.tsx.snap
+++ b/src/_page-tests/experience/__snapshots__/logo.test.tsx.snap
@@ -159,6 +159,15 @@ exports[`Experience/Logo renders 1`] = `
               </div>
             </a>
             <a
+              css={
+                Object {
+                  "map": undefined,
+                  "name": "ytumd6",
+                  "next": undefined,
+                  "styles": "text-decoration:none;",
+                  "toString": [Function],
+                }
+              }
               href="/experience/brand"
             >
               <div

--- a/src/_page-tests/experience/__snapshots__/typography.test.tsx.snap
+++ b/src/_page-tests/experience/__snapshots__/typography.test.tsx.snap
@@ -159,6 +159,15 @@ exports[`Experience/Typography renders 1`] = `
               </div>
             </a>
             <a
+              css={
+                Object {
+                  "map": undefined,
+                  "name": "ytumd6",
+                  "next": undefined,
+                  "styles": "text-decoration:none;",
+                  "toString": [Function],
+                }
+              }
               href="/experience/brand"
             >
               <div

--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -29,7 +29,7 @@ export async function initializeAnalytics() {
     ReactGA.initialize(publicRuntimeConfig.GA_KEY)
   }
   // vgo is set in bottom of _document.tsx
-  // @ts-expect-error
+  // @ts-ignore
   if (consented && window.vgo) {window.vgo('process', 'allowTracking')}
 }
 

--- a/src/experience/common/TopBar.tsx
+++ b/src/experience/common/TopBar.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import Hamburger from 'src/header/Hamburger'
+import { css } from '@emotion/react'
 import { useBooleanToggle } from 'src/hooks/useBooleanToggle'
 import { useScreenSize } from 'src/layout/ScreenSize'
 import LogoLightBg from 'src/logos/LogoLightBg'
@@ -45,7 +46,7 @@ export default function TopBar({ current, kitName }: Props) {
               {isMobile ? <RingsGlyph height={30} /> : <LogoLightBg height={30} />}
             </TouchableOpacity>
           </a>
-          <a href={current}>
+          <a href={current} css={kitBrand}>
             <TouchableOpacity style={styles.rowVerticalCenter}>
               <Text
                 // @ts-ignore -- added initial to the aug but it still isnt liking it
@@ -146,4 +147,8 @@ const styles = StyleSheet.create({
     marginBottom: 0,
     marginHorizontal: 15,
   },
+})
+
+const kitBrand = css({
+  textDecoration: 'none'
 })


### PR DESCRIPTION
Description
Removed the underline decoration from the navbar kit title.

What is the current behavior, and what is the updated/expected behavior with this PR?

**Before**
<img width="368" alt="Screen Shot 2021-03-15 at 12 43 55 PM" src="https://user-images.githubusercontent.com/55670305/111189686-bbf14900-858c-11eb-81ca-5b2707dbe1e5.png">

**After**
<img width="275" alt="Screen Shot 2021-03-15 at 12 50 14 PM" src="https://user-images.githubusercontent.com/55670305/111190011-0e326a00-858d-11eb-8e36-558d0be57bcf.png">

**Test Ran**
<img width="365" alt="Screen Shot 2021-03-15 at 12 57 44 PM" src="https://user-images.githubusercontent.com/55670305/111191080-14751600-858e-11eb-8111-112c7bcdca61.png">



Related issues
Fixes #110 
