### PR TITLE
changed the statsAddressess to just have addresses

### DIFF
--- a/public/static/locales/en/home.json
+++ b/public/static/locales/en/home.json
@@ -8,7 +8,7 @@
   "coverPhonesImage": "Phones showing various deFi apps built on the Celo Platform",
   "statsHeading": "PLATFORM STATS",
   "statsBlockCount": "Total blocks",
-  "statsAddresses": "Total wallet addresses",
+  "statsAddresses": "Total addresses",
   "statsTransactions": "Total transactions",
   "statsAvgTime": "Average block time",
   "whitePaper": "Read Celo White Paper",


### PR DESCRIPTION
**Description**

*A few sentences describing the overall effects and goals of the pull request's commits.*

on celo.org homepage platform stats widget remove "wallet" from wallet addresses so that its just "Addresses"

**What is the current behavior, and what is the updated/expected behavior with this PR?**

*Before*
<img width="221" alt="Screen Shot 2021-04-08 at 3 54 51 PM" src="https://user-images.githubusercontent.com/55670305/114092596-1037d200-9888-11eb-8851-fd333008f47d.png">

*After*
<img width="202" alt="Screen Shot 2021-04-08 at 3 57 38 PM" src="https://user-images.githubusercontent.com/55670305/114092626-1928a380-9888-11eb-8b49-2a1c7e1b9e3e.png">


**Tested**
<img width="376" alt="Screen Shot 2021-04-08 at 4 33 22 PM" src="https://user-images.githubusercontent.com/55670305/114092662-25acfc00-9888-11eb-8eaa-41920e490022.png">

Related issues
Fixes #148
