### PR TITLE
Bundle Size Reduction

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,7 @@ const envConfig = require('./env-config')
 const serverEnvConfig = require('./server-env-config')
 
 module.exports = withImages({
+  inlineImageLimit: 1024,
   future: {
     webpack5: true
   },

--- a/src/_page-tests/__snapshots__/about.test.tsx.snap
+++ b/src/_page-tests/__snapshots__/about.test.tsx.snap
@@ -121,7 +121,7 @@ exports[`About renders 1`] = `
             .ReactModal__Overlay {
               transition: transform 1000ms ease-in-out;
             }
-            
+
             .ReactModal__Overlay--after-open{
               transform: translateY(0);
             }
@@ -240,7 +240,6 @@ exports[`About renders 1`] = `
           </h3>
         </div>
       </div>
-      <div />
     </div>
   </div>
   <div

--- a/src/shared/VideoModal.tsx
+++ b/src/shared/VideoModal.tsx
@@ -1,12 +1,32 @@
+import dynamic from "next/dynamic"
 import * as React from 'react'
-import ReactModal from 'react-modal'
 import { Dimensions, Image, StyleSheet, Text, TouchableHighlight, View } from 'react-native'
-import YouTube from 'react-youtube'
 import AspectRatio from 'src/shared/AspectRatio'
 import EX from 'src/shared/EX'
 import PlayCircle from 'src/shared/PlayCircle'
 import { getSentry } from 'src/utils/sentry'
+interface YT {
+  videoId: string,
+  opts: { height: number, width: number,
+    playerVars: { autoplay: number, controls: number, playsinline: number, modestbranding: number,
+    },
+  },
+  onEnd: () => void
+  onReady: ({ target } : { target: any }) => void
+}
 
+interface ModalInterface {
+  isOpen: boolean
+  onRequestClose: () => void
+  style: any
+  aria: {
+    labelledby: string
+    describedby: string
+  }
+}
+
+const ReactModal = dynamic<ModalInterface>(import('react-modal'))
+const YouTube = dynamic<YT>(import('react-youtube'),  { ssr: false })
 interface Props {
   videoID: string
   previewImage?: string
@@ -27,7 +47,6 @@ export default class VideoModal extends React.Component<Props, State> {
   state = { playing: false, isClient: false, width: 0, height: 0 }
 
   componentDidMount() {
-    ReactModal.setAppElement('#__next')
     this.setState({ isClient: true })
     this.changeSize({ window: Dimensions.get('window') })
     Dimensions.addEventListener('change', this.changeSize)
@@ -90,7 +109,7 @@ export default class VideoModal extends React.Component<Props, State> {
             .ReactModal__Overlay {
               transition: transform 1000ms ease-in-out;
             }
-            
+
             .ReactModal__Overlay--after-open{
               transform: translateY(0);
             }


### PR DESCRIPTION
### Focusing on About Page 

bundle size: before *86k* now *17k*

lighthouse: 72 =91 perf 
#### BEFORE
<img width="509" alt="Screen Shot 2021-04-20 at 8 52 42 AM" src="https://user-images.githubusercontent.com/3814795/115429404-3b8bbc80-a1b8-11eb-80f5-05e09a637f75.png">

#### AFTER
<img width="458" alt="Screen Shot 2021-04-20 at 8 51 37 AM" src="https://user-images.githubusercontent.com/3814795/115429411-3c245300-a1b8-11eb-91fc-73185c078ff2.png">


#### how: 
* Next.js has an option to inline images base64 style. this however means they end up in the javascript code. I changed the threashold so that only images less than 1k will be included, which i think is a good compromise between reducing number of requests vs reducing bundles. 60k of the reduction on about page came from this

* LazyLoading components. About Page has A modal which plays a youtube video the ReactModal and YouTube components that do this added about 10k. these are now lazyloaded. 

#### bonus
the inline image change also reduce bundle for other pages 


![Screen Shot 2021-04-20 at 9 03 33 AM](https://user-images.githubusercontent.com/3814795/115429211-0c754b00-a1b8-11eb-8e5f-44ad8c190380.png)
