### PR TITLE
fixes addresses being assigned to block time sometimes

### DIFF
--- a/src/home/stats/useStatsRelay.ts
+++ b/src/home/stats/useStatsRelay.ts
@@ -44,6 +44,7 @@ export default function useStatsRelay() {
         if (addressAsNumber > state.addressCount) {
           return {...state, addressCount:addressAsNumber }
         }
+        return state
       case StatKeys.avgBlockTime:
         return {...state, avgBlockTime: action.value}
       case StatKeys.blockCount:


### PR DESCRIPTION
sometimes average block time would report a wrong number that was like total addresses. 

fixed by returned state so we dont fall thru the case switch