### PR TITLE
FIX bad rendering on mobile…

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -18,6 +18,7 @@ interface PropContext {
 
 export default class MyDocument extends Document<Props> {
   static async getInitialProps(context: DocumentContext & PropContext) {
+    const initialProps = await Document.getInitialProps(context)
     const userAgent = context?.req?.headers["user-agent"]
     setDimensionsForScreen(userAgent)
     AppRegistry.registerComponent("Main", () => Main)
@@ -35,7 +36,12 @@ export default class MyDocument extends Document<Props> {
       Sentry.captureException(context.err)
     }
 
-    return { ...page, styles: React.Children.toArray(styles), pathname: context.pathname }
+    return {
+      ...page,
+      styles: React.Children.toArray(styles),
+      pathname: context.pathname,
+      ...initialProps,
+    }
   }
 
   render() {

--- a/pages/alliance.tsx
+++ b/pages/alliance.tsx
@@ -3,7 +3,7 @@ import Alliance from "src/alliance/Main"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   return {
     props: {
       ...(await serverSideTranslations("en", [NameSpaces.common, NameSpaces.alliance])),

--- a/pages/audits.tsx
+++ b/pages/audits.tsx
@@ -2,7 +2,7 @@ import Audits from "src/terms/Audits"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   return {
     props: {
       ...(await serverSideTranslations("en", [NameSpaces.common, NameSpaces.audits])),

--- a/pages/brand-policy.tsx
+++ b/pages/brand-policy.tsx
@@ -2,7 +2,7 @@ import BrandPolicy from "src/terms/BrandPolicy"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   return {
     props: {
       ...(await serverSideTranslations("en", [NameSpaces.common, NameSpaces.brand])),

--- a/pages/celo-rewards-terms-and-conditions.tsx
+++ b/pages/celo-rewards-terms-and-conditions.tsx
@@ -2,7 +2,7 @@ import CeloRewardsTerms from "src/celo-rewards/CeloRewardsTerms"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, [NameSpaces.common, NameSpaces.celoRewards])),

--- a/pages/celo-rewards.tsx
+++ b/pages/celo-rewards.tsx
@@ -3,7 +3,7 @@ import CeloRewards from "src/celo-rewards/CeloRewards"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, [NameSpaces.common, NameSpaces.celoRewards])),

--- a/pages/code-of-conduct.tsx
+++ b/pages/code-of-conduct.tsx
@@ -3,7 +3,7 @@ import CodeOfConduct from "src/community/CodeOfConduct"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   return {
     props: {
       ...(await serverSideTranslations("en", [NameSpaces.common])),

--- a/pages/coinbase-earn.tsx
+++ b/pages/coinbase-earn.tsx
@@ -2,7 +2,7 @@ import Landing from "src/coinbase-earn/Landing"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   return {
     props: {
       ...(await serverSideTranslations("en", [NameSpaces.common, NameSpaces.cbe])),

--- a/pages/community.tsx
+++ b/pages/community.tsx
@@ -2,7 +2,7 @@ import ConnectPage from "src/community/CommunityPage"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   return {
     props: {
       ...(await serverSideTranslations("en", [NameSpaces.common, NameSpaces.community])),

--- a/pages/developers/index.tsx
+++ b/pages/developers/index.tsx
@@ -3,7 +3,7 @@ import DevelopersPage from "src/dev/DevelopersPage"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   return {
     props: {
       ...(await serverSideTranslations("en", [NameSpaces.common, NameSpaces.dev])),

--- a/pages/developers/wallet.tsx
+++ b/pages/developers/wallet.tsx
@@ -4,7 +4,7 @@ import Download from "src/download/MobileApp"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   return {
     props: {
       ...(await serverSideTranslations("en", [NameSpaces.common, NameSpaces.download])),

--- a/pages/experience/brand/color.tsx
+++ b/pages/experience/brand/color.tsx
@@ -3,7 +3,7 @@ import Color from "src/experience/brandkit/Color"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   return {
     props: {
       ...(await serverSideTranslations("en", [NameSpaces.common, NameSpaces.brand])),

--- a/pages/experience/brand/composition.tsx
+++ b/pages/experience/brand/composition.tsx
@@ -2,7 +2,7 @@ import Composition from "src/experience/brandkit/Composition"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   return {
     props: {
       ...(await serverSideTranslations("en", [NameSpaces.common, NameSpaces.brand])),

--- a/pages/experience/brand/exchange-icons.tsx
+++ b/pages/experience/brand/exchange-icons.tsx
@@ -3,7 +3,7 @@ import IconsExchangePage from "src/experience/brandkit/IconsExchangePage"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   return {
     props: {
       ...(await serverSideTranslations("en", [NameSpaces.common, NameSpaces.brand])),

--- a/pages/experience/brand/index.tsx
+++ b/pages/experience/brand/index.tsx
@@ -3,7 +3,7 @@ import Intro from "src/experience/brandkit/Intro"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   return {
     props: {
       ...(await serverSideTranslations("en", [NameSpaces.common, NameSpaces.brand])),

--- a/pages/experience/brand/logo.tsx
+++ b/pages/experience/brand/logo.tsx
@@ -3,7 +3,7 @@ import Logo from "src/experience/brandkit/Logo"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   return {
     props: {
       ...(await serverSideTranslations("en", [NameSpaces.common, NameSpaces.brand])),

--- a/pages/experience/brand/typography.tsx
+++ b/pages/experience/brand/typography.tsx
@@ -2,7 +2,7 @@ import Typography from "src/experience/brandkit/Typography"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   return {
     props: {
       ...(await serverSideTranslations("en", [NameSpaces.common, NameSpaces.brand])),

--- a/pages/experience/events/ambassador.tsx
+++ b/pages/experience/events/ambassador.tsx
@@ -2,7 +2,7 @@ import Circles from "src/experience/eventkit/AmbassadorPage"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   return {
     props: {
       ...(await serverSideTranslations("en", [NameSpaces.common])),

--- a/pages/experience/events/examples.tsx
+++ b/pages/experience/events/examples.tsx
@@ -2,7 +2,7 @@ import page from "src/experience/eventkit/ExamplesPage"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   return {
     props: {
       ...(await serverSideTranslations("en", [NameSpaces.common])),

--- a/pages/experience/events/flavor.tsx
+++ b/pages/experience/events/flavor.tsx
@@ -2,7 +2,7 @@ import flavor from "src/experience/eventkit/FlavorPage"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   return {
     props: {
       ...(await serverSideTranslations("en", [NameSpaces.common])),

--- a/pages/experience/events/index.tsx
+++ b/pages/experience/events/index.tsx
@@ -2,7 +2,7 @@ import Intro from "src/experience/eventkit/Intro"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   return {
     props: {
       ...(await serverSideTranslations("en", [NameSpaces.common])),

--- a/pages/experience/events/resources.tsx
+++ b/pages/experience/events/resources.tsx
@@ -2,7 +2,7 @@ import resources from "src/experience/eventkit/ResourcesPage"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   return {
     props: {
       ...(await serverSideTranslations("en", [NameSpaces.common])),

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,7 +2,7 @@ import Home from "src/home/Home"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   return {
     props: {
       ...(await serverSideTranslations("en", [NameSpaces.common, NameSpaces.home])),

--- a/pages/jobs.tsx
+++ b/pages/jobs.tsx
@@ -2,7 +2,7 @@ import JoinPage from "src/join/JoinPage"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, [NameSpaces.common, NameSpaces.jobs])),

--- a/pages/papers.tsx
+++ b/pages/papers.tsx
@@ -2,7 +2,7 @@ import Papers from "src/terms/Papers"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, [NameSpaces.common, NameSpaces.papers])),

--- a/pages/past-events.tsx
+++ b/pages/past-events.tsx
@@ -2,7 +2,7 @@ import PastEventsPage from "src/community/PastEventsPage"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, [NameSpaces.common, NameSpaces.community])),

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -3,7 +3,7 @@ import Privacy from "src/privacy/Privacy"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, [NameSpaces.common])),

--- a/pages/stake-off/terms.tsx
+++ b/pages/stake-off/terms.tsx
@@ -2,7 +2,7 @@ import StakeoffTerms from "src/terms/StakeOffTerms"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   return {
     props: {
       ...(await serverSideTranslations("en", [NameSpaces.common, NameSpaces.terms])),

--- a/pages/terms.tsx
+++ b/pages/terms.tsx
@@ -2,7 +2,7 @@ import TermsPortal from "src/terms/TermsPortal"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps({ locale }) {
+export async function getServerSideProps({ locale }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, [NameSpaces.common, NameSpaces.terms])),

--- a/pages/validators/explore/baklava.tsx
+++ b/pages/validators/explore/baklava.tsx
@@ -3,7 +3,7 @@ import { ValidatorsListAppWithNetwork } from "src/dev/ValidatorsListApp"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   return {
     props: {
       ...(await serverSideTranslations("en", [NameSpaces.common, NameSpaces.dev])),

--- a/pages/validators/explore/index.tsx
+++ b/pages/validators/explore/index.tsx
@@ -2,7 +2,7 @@ import { ValidatorsListAppWithNetwork } from "src/dev/ValidatorsListApp"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   return {
     props: {
       ...(await serverSideTranslations("en", [NameSpaces.common, NameSpaces.dev])),

--- a/pages/validators/index.tsx
+++ b/pages/validators/index.tsx
@@ -3,7 +3,7 @@ import ValidatorPage from "src/dev/ValidatorPage"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NameSpaces } from "src/i18n"
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   return {
     props: {
       ...(await serverSideTranslations("en", [NameSpaces.common, NameSpaces.dev])),


### PR DESCRIPTION
getStaticProps bypasses Document.getInitialProps but React Native Web Requires it. so we must use serverSideProps :(

This fixes glaring visual bugs on homepage and other pages when viewed on a mobile screen. 


when we eliminate RNW from _app and then from each page we can move back to static