### PR TITLE
Add banner communicating end of CELO rewards

### DIFF
--- a/public/locales/en/celoRewards.json
+++ b/public/locales/en/celoRewards.json
@@ -17,6 +17,7 @@
       "body": "Earn $10 worth of CELO per month"
     }
   },
+  "banner": "The CELO Rewards program has ended for now.",
   "buycUsd": "Add cUSD",
   "learnMore": "Learn More",
   "kickoff": {

--- a/public/locales/es/celoRewards.json
+++ b/public/locales/es/celoRewards.json
@@ -17,6 +17,7 @@
       "body": "Gana US$ 10 en CELO por mes"
     }
   },
+  "banner": "El Programa de recompensas en CELO ha finalizado por el momento.",
   "buycUsd": "Agregar cUSD",
   "learnMore": "Conoce más",
   "kickoff": {

--- a/public/locales/pt/celoRewards.json
+++ b/public/locales/pt/celoRewards.json
@@ -17,6 +17,7 @@
       "body": "Ganhe US$ 10 em CELO por mês"
     }
   },
+  "banner": "O Programa de recompensa em CELO terminou por enquanto.",
   "buycUsd": "Adicionar cUSD",
   "learnMore": "Saiba mais",
   "kickoff": {

--- a/public/locales/tl/celoRewards.json
+++ b/public/locales/tl/celoRewards.json
@@ -17,6 +17,7 @@
       "body": "Earn $10 worth of CELO per month"
     }
   },
+  "banner": "Ang Programang Mga Reward sa CELO ay natapos na.",
   "buycUsd": "Add cUSD",
   "learnMore": "Learn More",
   "kickoff": {

--- a/src/celo-rewards/CeloRewardsTerms.tsx
+++ b/src/celo-rewards/CeloRewardsTerms.tsx
@@ -182,14 +182,13 @@ export default CeloRewardsTerms
 const styles = StyleSheet.create({
   container: {
     marginTop: HEADER_HEIGHT,
-    paddingTop: HEADER_HEIGHT,
   },
   banner: {
     backgroundColor: colors.lightGray,
     fontSize: 20,
     padding: 8,
     borderRadius: 4,
-    marginBottom: 100,
+    marginBottom: 20,
   },
   listItem: {
     fontSize: 18,

--- a/src/celo-rewards/CeloRewardsTerms.tsx
+++ b/src/celo-rewards/CeloRewardsTerms.tsx
@@ -63,6 +63,7 @@ function CeloRewardsTerms() {
         description={t("description.first")}
       />
       <View style={styles.container}>
+        <TitleAndDescription title={''} description={t("banner")} descriptionStyle={styles.banner} />
         <TitleAndDescription title={t("terms.title")} />
         <TitleAndDescription
           title={t("terms.howItWorks.title")}
@@ -182,6 +183,13 @@ const styles = StyleSheet.create({
   container: {
     marginTop: HEADER_HEIGHT,
     paddingTop: HEADER_HEIGHT,
+  },
+  banner: {
+    backgroundColor: colors.lightGray,
+    fontSize: 20,
+    padding: 8,
+    borderRadius: 4,
+    marginBottom: 100,
   },
   listItem: {
     fontSize: 18,


### PR DESCRIPTION
Added banner communicating end of CELO rewards:

![Screen Shot 2021-06-22 at 18 31 59](https://user-images.githubusercontent.com/6062888/123002308-2bdf4e80-d388-11eb-91dc-16006ea6fcc8.png)

