### PR TITLE
Render a h2 with an h1 style for the home page 

### DIFF
--- a/src/contentful/grid2-cells/FreeContent.tsx
+++ b/src/contentful/grid2-cells/FreeContent.tsx
@@ -1,11 +1,10 @@
 import { css } from "@emotion/react"
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
-import { flex, WHEN_MOBILE } from "src/estyles"
+import { flex, fonts, WHEN_MOBILE } from "src/estyles"
 import { renderNode } from "src/contentful/nodes/nodes"
 import { BLOCKS, INLINES, Block, Document } from "@contentful/rich-text-types"
 import { BUTTON } from "src/contentful/nodes/embeds/BUTTON"
 import { GALLARY } from "src/contentful/nodes/embeds/GALLARY"
-import { typeFaces } from "src/styles"
 
 const EMBEDDABLE = {
   ...BUTTON,
@@ -28,24 +27,14 @@ const OPTIONS = {
   renderNode: {
     ...renderNode,
     [BLOCKS.HEADING_1]: (_, children: string) => {
-      return <h2 css={h1Font}>{children}</h2>
+      return <h2 css={h1ResponsiveCss}>{children}</h2>
     },
     [BLOCKS.EMBEDDED_ENTRY]: embedded,
     [INLINES.EMBEDDED_ENTRY]: embedded,
   },
 }
 
-const h1Font = css({
-  fontFamily: typeFaces.garamond,
-  fontSize: "48px",
-  fontWeight: "normal",
-  lineHeight: "56px",
-  [WHEN_MOBILE]: {
-    fontSize: "36px",
-    lineHeight: "40px",
-  }
-})
-
+const h1ResponsiveCss = css(fonts.h1, { [WHEN_MOBILE]: fonts.h1Mobile })
 interface Props {
   colSpan: number
   body: Document

--- a/src/contentful/grid2-cells/FreeContent.tsx
+++ b/src/contentful/grid2-cells/FreeContent.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react"
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
-import { flex } from "src/estyles"
+import { flex, WHEN_MOBILE } from "src/estyles"
 import { renderNode } from "src/contentful/nodes/nodes"
 import { BLOCKS, INLINES, Block, Document } from "@contentful/rich-text-types"
 import { BUTTON } from "src/contentful/nodes/embeds/BUTTON"
@@ -38,7 +38,12 @@ const OPTIONS = {
 const h1Font = css({
   fontFamily: typeFaces.garamond,
   fontSize: "48px",
-  fontWeight: "normal"
+  fontWeight: "normal",
+  lineHeight: "56px",
+  [WHEN_MOBILE]: {
+    fontSize: "36px",
+    lineHeight: "40px",
+  }
 })
 
 interface Props {

--- a/src/contentful/grid2-cells/FreeContent.tsx
+++ b/src/contentful/grid2-cells/FreeContent.tsx
@@ -5,6 +5,7 @@ import { renderNode } from "src/contentful/nodes/nodes"
 import { BLOCKS, INLINES, Block, Document } from "@contentful/rich-text-types"
 import { BUTTON } from "src/contentful/nodes/embeds/BUTTON"
 import { GALLARY } from "src/contentful/nodes/embeds/GALLARY"
+import { typeFaces } from "src/styles"
 
 const EMBEDDABLE = {
   ...BUTTON,
@@ -26,10 +27,19 @@ function embedded(node: Block) {
 const OPTIONS = {
   renderNode: {
     ...renderNode,
+    [BLOCKS.HEADING_1]: (_, children: string) => {
+      return <h2 css={h1Font}>{children}</h2>
+    },
     [BLOCKS.EMBEDDED_ENTRY]: embedded,
     [INLINES.EMBEDDED_ENTRY]: embedded,
   },
 }
+
+const h1Font = css({
+  fontFamily: typeFaces.garamond,
+  fontSize: "48px",
+  fontWeight: "normal"
+})
 
 interface Props {
   colSpan: number
@@ -59,4 +69,4 @@ const rootCss = css(flex, {
   },
 })
 
-const darkModeText = css({ "h2, h3, h4, h5, h6, p, div, ul, span": { color: "white" } })
+const darkModeText = css({ "h1, h2, h3, h4, h5, h6, p, div, ul, span": { color: "white" } })

--- a/src/home/Cover.tsx
+++ b/src/home/Cover.tsx
@@ -22,7 +22,6 @@ interface Props {
 }
 
 export default function Cover(props: Props) {
-  debugger
   const { isDesktop, isTablet, bannerHeight } = useScreenSize()
   const { t } = useTranslation(NameSpaces.home)
   return (

--- a/src/public-sector/FreeContent.tsx
+++ b/src/public-sector/FreeContent.tsx
@@ -1,4 +1,4 @@
-import {css} from "@emotion/react"
+import { css } from "@emotion/react"
 import { documentToReactComponents } from '@contentful/rich-text-react-renderer'
 import { flex } from "src/estyles"
 import { renderNode } from "src/contentful/nodes/nodes"
@@ -25,6 +25,6 @@ export function FreeContent({ colSpan, body, cssStyle, backgroundColor, darkMode
   )
 }
 
-const rootCss = css(flex,{})
+const rootCss = css(flex, {})
 
-const darkModeText = css({"h2, h3, h4, h5, h6, p, div, ul, span": {color:"white"}})
+const darkModeText = css({ "h2, h3, h4, h5, h6, p, div, ul, span": { color: "white" } })


### PR DESCRIPTION
We want to have h1 styles, but only have one h1 tag on the home page for accessibility reasons. 

For some reason, it wasn't working correctly when I just wanted to use the fonts.h1 style, so I had to create a new style in this page, and it worked.

Mobile styles are included, and uses the same styles as the h1 font. 

I know this is a duplication of some code, but when using imported css styles of fonts.h1, i got something like this: 
![image](https://user-images.githubusercontent.com/12700801/124310067-84e57a00-db20-11eb-90bb-7ea7dded2a65.png)

Screenshot below of using styles defined in the page:
 
![image](https://user-images.githubusercontent.com/12700801/124309752-0ee11300-db20-11eb-9db1-fb5d8e60f47a.png)
