### PR TITLE
tuesday changes

### DIFF
--- a/pages/use-a-dapp.tsx
+++ b/pages/use-a-dapp.tsx
@@ -9,7 +9,7 @@ export default CommonPage
 export const getServerSideProps: GetServerSideProps = async function getServerSideProps({
   locale,
 }) {
-  const page = await getPageBySlug("use-dapp", { locale: "en-US" }, true)
+  const page = await getPageBySlug("use-a-dapp", { locale: "en-US" }, true)
 
   if (!page) {
     return { notFound: true }

--- a/pages/v6/[slug].tsx
+++ b/pages/v6/[slug].tsx
@@ -81,6 +81,7 @@ function pageSwitch(
       const coverFields = section.fields as CoverContentType
       return (
         <Cover
+          superSize={coverFields.superSize}
           key={section.sys.id}
           darkMode={coverFields.darkMode}
           illoFirst={coverFields.illoFirst}

--- a/src/_page-tests/__snapshots__/index.test.tsx.snap
+++ b/src/_page-tests/__snapshots__/index.test.tsx.snap
@@ -56,9 +56,9 @@ exports[`HomePage renders 1`] = `
       css={
         Object {
           "map": undefined,
-          "name": "zurjp",
+          "name": "kitalr",
           "next": undefined,
-          "styles": "box-sizing:border-box;display:flex;flex-direction:column;;align-items:center;z-index:10;@media (min-width: 992px){width:100%;z-index:20;}@media (min-width: 576px) and (max-width: 992px){padding-top:72px;}@media (max-width: 576px){padding-top:24px;padding-bottom:16px;}@media (max-width: 400px) and (min-height: 790px){padding-bottom:0;}",
+          "styles": "box-sizing:border-box;display:flex;flex-direction:column;;align-items:center;z-index:10;@media (min-width: 992px){width:100%;z-index:20;padding-top:48px;}@media (min-width: 576px) and (max-width: 992px){padding-top:72px;}@media (max-width: 576px){padding-top:24px;padding-bottom:16px;}@media (max-width: 400px) and (min-height: 790px){padding-bottom:0;}",
           "toString": [Function],
         }
       }

--- a/src/_page-tests/__snapshots__/index.test.tsx.snap
+++ b/src/_page-tests/__snapshots__/index.test.tsx.snap
@@ -351,5 +351,219 @@ exports[`HomePage renders 1`] = `
       </section>
     </div>
   </div>
+  <section
+    css={
+      Object {
+        "map": undefined,
+        "name": "pnyh7x",
+        "next": undefined,
+        "styles": "box-sizing:border-box;display:flex;flex-direction:column;;overflow:hidden;align-items:center;align-self:center;width:100%;;",
+        "toString": [Function],
+      }
+    }
+  >
+    <div
+      css={
+        Object {
+          "map": undefined,
+          "name": "4s0z69",
+          "next": undefined,
+          "styles": "box-sizing:border-box;display:flex;flex-direction:column;;align-self:center;flex-direction:column;padding-left:12px;padding-right:12px;width:100%;max-width:100vw;overflow:hidden;flex-wrap:wrap;column-gap:24px;@media (min-width: 576px) and (max-width: 992px){display:grid;grid-auto-rows:auto;align-self:center;flex-direction:row;padding-right:24px;padding-left:24px;width:100%;max-width:982px;}@media (min-width: 992px){display:grid;grid-auto-rows:auto;align-self:center;width:100%;max-width:1104px;};@media (min-width: 992px){grid-template-columns:1fr 1fr 1fr ;}@media (min-width: 576px) and (max-width: 992px){grid-template-columns:1fr 1fr 1fr ;}",
+          "toString": [Function],
+        }
+      }
+      id="test"
+    >
+      <div
+        css={
+          Object {
+            "map": undefined,
+            "name": "1usgoqe",
+            "next": undefined,
+            "styles": "box-sizing:border-box;display:flex;flex-direction:column;;flex:1;justify-content:space-between;margin-bottom:36px;@media (max-width: 576px){align-items:center;align-content:center;}",
+            "toString": [Function],
+          }
+        }
+      >
+        <div
+          css={
+            Object {
+              "map": undefined,
+              "name": "qb3b49",
+              "next": undefined,
+              "styles": "box-sizing:border-box;display:flex;flex-direction:column;;flex:1;p:first-of-type{margin-top:0;}p:last-of-type{margin-bottom:0;}@media (max-width: 576px){align-items:center;align-content:center;text-align:center;max-width:288px;}",
+              "toString": [Function],
+            }
+          }
+        >
+          <img
+            css={
+              Object {
+                "map": undefined,
+                "name": "1mf35eq",
+                "next": undefined,
+                "styles": "width:100px;height:100px;",
+                "toString": [Function],
+              }
+            }
+            height={100}
+            width={100}
+          />
+          <h4
+            css={
+              Object {
+                "map": undefined,
+                "name": "9oenxr",
+                "next": undefined,
+                "styles": "font-weight:normal;margin:0;margin-block-start:0;margin-block-end:0;;font-family:Jost, futura-pt, futura, sans-serif;font-size:24px;line-height:28;font-weight:400;text-rendering:geometricPrecision;color:#2E3338;line-height:28px;;margin-top:16px;margin-bottom:12px;;",
+                "toString": [Function],
+              }
+            }
+          >
+            Blurb romeo
+          </h4>
+          <p
+            css={
+              Object {
+                "map": undefined,
+                "name": "ronyck",
+                "next": undefined,
+                "styles": "font-family:EB Garamond, eb-garamond, Garamond, serif;font-size:20px;line-height:28;text-rendering:geometricPrecision;color:#2E3338;line-height:28px;",
+                "toString": [Function],
+              }
+            }
+          >
+            Hello World
+          </p>
+        </div>
+      </div>
+      <div
+        css={
+          Object {
+            "map": undefined,
+            "name": "1usgoqe",
+            "next": undefined,
+            "styles": "box-sizing:border-box;display:flex;flex-direction:column;;flex:1;justify-content:space-between;margin-bottom:36px;@media (max-width: 576px){align-items:center;align-content:center;}",
+            "toString": [Function],
+          }
+        }
+      >
+        <div
+          css={
+            Object {
+              "map": undefined,
+              "name": "qb3b49",
+              "next": undefined,
+              "styles": "box-sizing:border-box;display:flex;flex-direction:column;;flex:1;p:first-of-type{margin-top:0;}p:last-of-type{margin-bottom:0;}@media (max-width: 576px){align-items:center;align-content:center;text-align:center;max-width:288px;}",
+              "toString": [Function],
+            }
+          }
+        >
+          <img
+            css={
+              Object {
+                "map": undefined,
+                "name": "1mf35eq",
+                "next": undefined,
+                "styles": "width:100px;height:100px;",
+                "toString": [Function],
+              }
+            }
+            height={100}
+            width={100}
+          />
+          <h4
+            css={
+              Object {
+                "map": undefined,
+                "name": "9oenxr",
+                "next": undefined,
+                "styles": "font-weight:normal;margin:0;margin-block-start:0;margin-block-end:0;;font-family:Jost, futura-pt, futura, sans-serif;font-size:24px;line-height:28;font-weight:400;text-rendering:geometricPrecision;color:#2E3338;line-height:28px;;margin-top:16px;margin-bottom:12px;;",
+                "toString": [Function],
+              }
+            }
+          >
+            Blurb soma
+          </h4>
+          <p
+            css={
+              Object {
+                "map": undefined,
+                "name": "ronyck",
+                "next": undefined,
+                "styles": "font-family:EB Garamond, eb-garamond, Garamond, serif;font-size:20px;line-height:28;text-rendering:geometricPrecision;color:#2E3338;line-height:28px;",
+                "toString": [Function],
+              }
+            }
+          >
+            Hello World
+          </p>
+        </div>
+      </div>
+      <div
+        css={
+          Object {
+            "map": undefined,
+            "name": "1usgoqe",
+            "next": undefined,
+            "styles": "box-sizing:border-box;display:flex;flex-direction:column;;flex:1;justify-content:space-between;margin-bottom:36px;@media (max-width: 576px){align-items:center;align-content:center;}",
+            "toString": [Function],
+          }
+        }
+      >
+        <div
+          css={
+            Object {
+              "map": undefined,
+              "name": "qb3b49",
+              "next": undefined,
+              "styles": "box-sizing:border-box;display:flex;flex-direction:column;;flex:1;p:first-of-type{margin-top:0;}p:last-of-type{margin-bottom:0;}@media (max-width: 576px){align-items:center;align-content:center;text-align:center;max-width:288px;}",
+              "toString": [Function],
+            }
+          }
+        >
+          <img
+            css={
+              Object {
+                "map": undefined,
+                "name": "1mf35eq",
+                "next": undefined,
+                "styles": "width:100px;height:100px;",
+                "toString": [Function],
+              }
+            }
+            height={100}
+            width={100}
+          />
+          <h4
+            css={
+              Object {
+                "map": undefined,
+                "name": "9oenxr",
+                "next": undefined,
+                "styles": "font-weight:normal;margin:0;margin-block-start:0;margin-block-end:0;;font-family:Jost, futura-pt, futura, sans-serif;font-size:24px;line-height:28;font-weight:400;text-rendering:geometricPrecision;color:#2E3338;line-height:28px;;margin-top:16px;margin-bottom:12px;;",
+                "toString": [Function],
+              }
+            }
+          >
+            Blurb rico
+          </h4>
+          <p
+            css={
+              Object {
+                "map": undefined,
+                "name": "ronyck",
+                "next": undefined,
+                "styles": "font-family:EB Garamond, eb-garamond, Garamond, serif;font-size:20px;line-height:28;text-rendering:geometricPrecision;color:#2E3338;line-height:28px;",
+                "toString": [Function],
+              }
+            }
+          >
+            Hello World
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
 </div>
 `;

--- a/src/_page-tests/index.test.tsx
+++ b/src/_page-tests/index.test.tsx
@@ -2,6 +2,66 @@ import HomePage from "pages/index"
 import * as React from "react"
 import * as renderer from "react-test-renderer"
 import { TestProvider } from "src/_page-tests/test-utils"
+import { ContentfulPage, GridRowContentType } from "src/utils/contentful"
+import { Props as BlurbProps } from "src/contentful/grid2-cells/Blurb"
+import { Entry } from "contentful"
+import { BLOCKS } from "@contentful/rich-text-types"
+
+function blurbFactory(unique): Entry<BlurbProps> {
+  return {
+    sys: {
+      id: unique,
+      type: "",
+      locale: "en",
+      createdAt: "2021-07-01",
+      updatedAt: "2021-07-01",
+      contentType: { sys: { id: "proposition", type: "Link", linkType: "ContentType" } },
+    },
+    fields: {
+      title: `Blurb ${unique}`,
+      body: {
+        nodeType: BLOCKS.DOCUMENT,
+        content: [
+          {
+            nodeType: BLOCKS.PARAGRAPH,
+            content: [{ nodeType: "text", value: "Hello World", marks: [], data: {} }],
+            data: {},
+          },
+        ],
+        data: {},
+      },
+    },
+    toPlainObject: () => this,
+    update: () => this,
+  }
+}
+
+const TestData: ContentfulPage<GridRowContentType> = {
+  title: "Celo Home",
+  description: "A description of Celo",
+  slug: "home",
+  sections: [
+    {
+      sys: {
+        id: "1",
+        type: "",
+        locale: "en",
+        createdAt: "2021-07-01",
+        updatedAt: "2021-07-01",
+        contentType: { sys: { id: "grid-row", type: "Link", linkType: "ContentType" } },
+      },
+      fields: {
+        id: "test",
+        columns: 3,
+        cells: [blurbFactory("romeo"), blurbFactory("soma"), blurbFactory("rico")],
+      },
+      toPlainObject: () => this,
+      update: () => this,
+    },
+  ],
+}
+
+
 
 describe("HomePage", () => {
   it("renders", async () => {
@@ -9,10 +69,10 @@ describe("HomePage", () => {
       .create(
         <TestProvider>
           <HomePage
-            title="Celo Home"
-            description="A description of Celo"
-            slug="home"
-            sections={[]}
+            title={TestData.title}
+            description={TestData.description}
+            slug={TestData.slug}
+            sections={TestData.sections}
           />
         </TestProvider>
       )

--- a/src/contentful/Cover.tsx
+++ b/src/contentful/Cover.tsx
@@ -13,9 +13,19 @@ import {
 import { GridRow } from "src/layout/Grid2"
 import { TABLET_BREAKPOINT } from "src/shared/Styles"
 import { CoverContentType } from "src/utils/contentful"
-import renderNode from "src/contentful/nodes/paragraph"
+import renderers from "src/contentful/nodes/enodes"
 import Button, { SIZE } from "src/shared/Button.3"
 import { useScreenSize } from "src/layout/ScreenSize"
+import { BLOCKS } from "@contentful/rich-text-types"
+
+const OPTIONS = {
+  renderNode: {
+    ...renderers,
+    [BLOCKS.HEADING_1]: (_, children: string) => {
+      return <h2 css={fonts.h1}>{children}</h2>
+    },
+  },
+}
 
 export default function Cover(props: CoverContentType) {
   const { isMobile } = useScreenSize()
@@ -30,9 +40,11 @@ export default function Cover(props: CoverContentType) {
       css={props.illoFirst ? imageFirstRootCss : rootCss}
     >
       <div css={contentCss}>
-        <h1 css={css(titleCss, props.darkMode && whiteText)}>{props.title}</h1>
+        <h1 css={css(props.superSize ? titleCss : fonts.h1, props.darkMode && whiteText)}>
+          {props.title}
+        </h1>
         <span css={props.darkMode ? subtitleDarkMode : subtitleCss}>
-          {documentToReactComponents(props.subTitle, { renderNode })}
+          {documentToReactComponents(props.subTitle, OPTIONS)}
         </span>
         <div css={linkAreaCss}>
           {props.links?.map((link) => (
@@ -116,7 +128,7 @@ const subtitleCss = css({
 })
 
 const subtitleDarkMode = css(whiteText, subtitleCss, {
-  p: whiteText,
+  "h1, h2, h3, h4, p": whiteText,
 })
 
 const contentCss = css(flex, {

--- a/src/contentful/HorizontalRule.tsx
+++ b/src/contentful/HorizontalRule.tsx
@@ -1,0 +1,26 @@
+import { css } from "@emotion/react"
+import { WHEN_DESKTOP, WHEN_TABLET } from "src/estyles"
+import { colors } from "src/styles"
+
+export default function HR() {
+  return <hr css={rootCss} />
+}
+const gap = 24.0
+
+const rootCss = css({
+  width: "100%",
+  border: 0,
+  height: 2,
+  alignSelf: "center",
+  backgroundColor: colors.lightGray,
+  marginLeft: gap / 2,
+  marginRight: gap / 2,
+  [WHEN_DESKTOP]: {
+    maxWidth: 1080 + gap,
+  },
+  [WHEN_TABLET]: {
+    marginRight: gap,
+    marginLeft: gap,
+    maxWidth: 958 + gap,
+  },
+})

--- a/src/contentful/grid2-cells/FreeContent.tsx
+++ b/src/contentful/grid2-cells/FreeContent.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react"
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
 import { flex, fonts, WHEN_MOBILE } from "src/estyles"
-import { renderNode } from "src/contentful/nodes/nodes"
+import renderNode from "src/contentful/nodes/enodes"
 import { BLOCKS, INLINES, Block, Document } from "@contentful/rich-text-types"
 import { BUTTON } from "src/contentful/nodes/embeds/BUTTON"
 import { GALLARY } from "src/contentful/nodes/embeds/GALLARY"

--- a/src/contentful/grid2-cells/Heading.tsx
+++ b/src/contentful/grid2-cells/Heading.tsx
@@ -35,7 +35,18 @@ export function Heading(props: Props & HeadingContentType) {
           height={imageFile.details.image.height}
         />
       )}
-      {<h2 css={css(titleCSS, props.titleCss, props.darkMode && whiteText)}>{props.title}</h2>}
+      {
+        <h2
+          css={css(
+            props.displayTitleH1 ? fonts.h1 : fonts.h2,
+            titleCSS,
+            props.titleCss,
+            props.darkMode && whiteText
+          )}
+        >
+          {props.title}
+        </h2>
+      }
       {documentToReactComponents(props.subTitle, subtitleOptions)}
     </div>
   )
@@ -50,7 +61,7 @@ const subtitleCss = css(fonts.h4, {
   textAlign: "center",
 })
 
-const titleCSS = css(fonts.h1, {
+const titleCSS = css({
   textAlign: "center",
   marginBottom: 24,
 })

--- a/src/contentful/nodes/enodes.tsx
+++ b/src/contentful/nodes/enodes.tsx
@@ -1,34 +1,31 @@
 import { RenderNode } from "@contentful/rich-text-react-renderer"
-import { BLOCKS, INLINES } from "@contentful/rich-text-types"
-import { Asset } from "contentful"
+import { BLOCKS } from "@contentful/rich-text-types"
 import * as React from "react"
-import { Text } from "react-native"
-import { H1, H2, H3, H4 } from "src/fonts/Fonts"
-import InlineAnchor from "src/shared/InlineAnchor"
-import { fonts, standardStyles } from "src/styles"
+import { Asset } from "contentful"
 import Image from "next/image"
+import { fonts } from "src/estyles"
 
-export const renderNode: RenderNode = {
+const renderNode: RenderNode = {
   [BLOCKS.HEADING_1]: (_, children: string) => {
-    return <H1>{children}</H1>
+    return <h2 css={fonts.h1}>{children}</h2>
   },
   [BLOCKS.HEADING_2]: (_, children: string) => {
-    return <H2 style={standardStyles.blockMarginTopTablet}>{children}</H2>
+    return <h2 css={fonts.h2}>{children}</h2>
   },
   [BLOCKS.HEADING_3]: (_, children: string) => {
-    return <H3 style={standardStyles.blockMarginTopTablet}>{children}</H3>
+    return <h3 css={fonts.h3}>{children}</h3>
   },
   [BLOCKS.HEADING_4]: (_, children: string) => {
-    return <H4 style={standardStyles.elementalMargin}>{children}</H4>
+    return <h4 css={fonts.h4}>{children}</h4>
   },
   [BLOCKS.HEADING_5]: (_, children: string) => {
-    return <Text style={fonts.h5}>{children}</Text>
+    return <h5 css={fonts.h5}>{children}</h5>
+  },
+  [BLOCKS.HEADING_6]: (_, children: string) => {
+    return <h6 css={fonts.h6}>{children}</h6>
   },
   [BLOCKS.PARAGRAPH]: (_, children: string) => {
-    return <Text style={[fonts.p, standardStyles.halfElement]}>{children}</Text>
-  },
-  [INLINES.HYPERLINK]: (node, children: string) => {
-    return <InlineAnchor href={node.data.uri}>{children}</InlineAnchor>
+    return <p css={fonts.body}>{children}</p>
   },
   [BLOCKS.EMBEDDED_ASSET]: (node) => {
     const asset = node.data.target as Asset
@@ -52,3 +49,5 @@ export const renderNode: RenderNode = {
     )
   },
 }
+
+export default renderNode

--- a/src/home/Cover.tsx
+++ b/src/home/Cover.tsx
@@ -140,6 +140,7 @@ const useableArea = css(flex, {
   [WHEN_DESKTOP]: {
     width: backgroundDesktopSize.width,
     zIndex: 20,
+    paddingTop: 48,
   },
   [WHEN_TABLET]: {
     paddingTop: 72,

--- a/src/home/cellSwitch.tsx
+++ b/src/home/cellSwitch.tsx
@@ -2,6 +2,7 @@ import { Entry } from "contentful"
 import { FreeContent } from "src/contentful/grid2-cells/FreeContent"
 import Blurb, { Props as BlurbProps } from "src/contentful/grid2-cells/Blurb"
 import { CellContentType, FreeContentType } from "src/utils/contentful"
+import * as React from "react"
 
 export function cellSwitch(entry: Entry<CellContentType>, darkMode: boolean) {
   if (entry) {

--- a/src/public-sector/CommonContentFullPage.tsx
+++ b/src/public-sector/CommonContentFullPage.tsx
@@ -18,6 +18,7 @@ import { GALLARY } from "src/contentful/nodes/embeds/GALLARY"
 import { TABLE } from "src/contentful/nodes/embeds/TABLE"
 import { BLOCKS, INLINES, Block } from "@contentful/rich-text-types"
 import Cover from "src/contentful/Cover"
+import HR from "src/contentful/HorizontalRule"
 import { ROW } from "src/contentful/nodes/embeds/ROW"
 
 type Props = ContentfulPage<GridRowContentType | SectionType>
@@ -75,6 +76,7 @@ function pageSwitch(
         <Cover
           key={section.sys.id}
           darkMode={coverFields.darkMode}
+          superSize={coverFields.superSize}
           illoFirst={coverFields.illoFirst}
           title={coverFields.title}
           subTitle={coverFields.subTitle}
@@ -102,6 +104,8 @@ function pageSwitch(
           )}
         </GridRow>
       )
+    case "horizontal":
+      return <HR key={section.sys.id} />
     default:
       const sectionfields = section.fields as SectionType
       return (

--- a/src/public-sector/cellSwitch.tsx
+++ b/src/public-sector/cellSwitch.tsx
@@ -76,6 +76,7 @@ export function cellSwitch(entry: Entry<CellContentType>, darkMode: boolean, col
             darkMode={darkMode}
             span={columns}
             title={heading.title}
+            displayTitleH1={heading.displayTitleH1}
             subTitle={heading.subTitle}
             titleCss={heading.titleCss}
             subTitleCss={heading.subTitleCss}

--- a/src/utils/contentful.ts
+++ b/src/utils/contentful.ts
@@ -142,6 +142,7 @@ export interface PlaylistContentType {
 
 export interface HeadingContentType {
   title: string
+  displayTitleH1?: boolean
   subTitle: Document
   titleCss?: CSSObject
   subTitleCss?: CSSObject
@@ -167,6 +168,7 @@ export interface GridRowContentType {
 
 export interface CoverContentType {
   title: string
+  superSize: boolean
   subTitle: Document
   links?: Entry<ContentfulButton>[]
   imageDesktop: Asset


### PR DESCRIPTION
- create a new nodeRenderer for regular h* tags instead of using the RNW version
- let cover subtitle be many different styles
- add optional superSize for the title on cover (used posthaste on the public sector page, since it bigger than h1) 
- remove unused dynamic imports 
- home page cover add padding to top
- add a `HR` component for between grid sections