### PR TITLE
fix safari row height bug

### DIFF
--- a/src/plumo/Rounds.tsx
+++ b/src/plumo/Rounds.tsx
@@ -197,6 +197,7 @@ const Phases = React.memo(function Phases({phase, setPhase, phase2Started}: Phas
 const rootCss = css({
   maxWidth: 720,
   marginTop: 16,
+  display: "grid", // fixes a safari bug where row heights were wrong
 })
 
 const dropdownsCss = css({


### PR DESCRIPTION
Fixes Bug in safari where row heights are too high. oddly setting the container of the grid to be a grid itself fixes this. 
![Screen Shot 2021-07-14 at 9 17 26 AM](https://user-images.githubusercontent.com/3814795/125657746-e46213ae-698b-49ab-9b3a-39f0c779ed54.png)
