### PR TITLE
fix cover tablet stretching

### DIFF
--- a/src/contentful/Cover.tsx
+++ b/src/contentful/Cover.tsx
@@ -71,7 +71,7 @@ export default function Cover(props: CoverContentType) {
           props.imageFit === "contain"
             ? css(illoContain, {
                 [WHEN_TABLET]: {
-                  paddingTop: `${(size?.height || 1 / size?.width || 1) * 100}%`,
+                  paddingTop: `${((size?.height || 1) / (size?.width || 1)) * 100}%`,
                 },
               })
             : illoCss


### PR DESCRIPTION
fix issue on tablet where math caused image padding and size to be 100000% of width and thus very stretched

# before 
![Screen Shot 2021-09-23 at 2 07 55 PM](https://user-images.githubusercontent.com/3814795/134584218-4c58b23b-3eaf-4ad2-b2da-e4fef444f586.png)

# after
![Screen Shot 2021-09-23 at 2 08 44 PM](https://user-images.githubusercontent.com/3814795/134584348-be9eedab-580f-426f-92e9-b209243c9af1.png)
