### PR TITLE
Henrynunez112/exchange logos

### DIFF
--- a/src/contentful/nodes/embeds/ROW.tsx
+++ b/src/contentful/nodes/embeds/ROW.tsx
@@ -40,15 +40,14 @@ export const ROW = {
             const item = fields as Item
             const imageFields = item?.image?.fields
             const rendered = (
-              <div css={logoContainer}>
+              <div key={sys.id} css={logoContainer}>
                 <img
-                  key={sys.id}
                   alt={imageFields?.description}
                   src={imageFields?.file?.url}
                   width={imageFields?.file?.details?.image?.width}
                   height={imageFields?.file?.details?.image?.height}
                 />
-                <p css={logoTitle}>{item.title}</p>
+                {item.title ? <p css={logoTitle}>{item.title}</p> : null}
               </div>
             )
 
@@ -72,11 +71,10 @@ const rootStyle = css(flexRow, {
 
 const logoContainer = css(flexRow, {
   alignItems: "center",
-  marginLeft: 12,
-  marginRight: 12,
 })
 
 const logoTitle = css(jost, {
   fontSize: 16,
   fontWeight: 500,
+  marginRight: 24,
 })

--- a/src/contentful/nodes/embeds/ROW.tsx
+++ b/src/contentful/nodes/embeds/ROW.tsx
@@ -1,5 +1,5 @@
 import { css, CSSObject } from "@emotion/react"
-import { flexRow, WHEN_MOBILE } from "src/estyles"
+import { flexRow, WHEN_MOBILE, jost } from "src/estyles"
 import { Entry } from "contentful"
 import { GalleryItem } from "src/utils/contentful"
 import { Props as ButtonShape } from "src/contentful/nodes/embeds/BUTTON"
@@ -76,7 +76,7 @@ const logoContainer = css(flexRow, {
   marginRight: 12,
 })
 
-const logoTitle = css({
+const logoTitle = css(jost, {
   fontSize: 16,
   fontWeight: 500,
 })

--- a/src/contentful/nodes/embeds/ROW.tsx
+++ b/src/contentful/nodes/embeds/ROW.tsx
@@ -2,7 +2,7 @@ import { css, CSSObject } from "@emotion/react"
 import { flexRow, WHEN_MOBILE } from "src/estyles"
 import { Entry } from "contentful"
 import { GalleryItem } from "src/utils/contentful"
-import {Props as ButtonShape} from "src/contentful/nodes/embeds/BUTTON"
+import { Props as ButtonShape } from "src/contentful/nodes/embeds/BUTTON"
 import Button from "src/shared/Button.3"
 
 type Item = GalleryItem
@@ -40,13 +40,16 @@ export const ROW = {
             const item = fields as Item
             const imageFields = item?.image?.fields
             const rendered = (
-              <img
-                key={sys.id}
-                alt={imageFields?.description}
-                src={imageFields?.file?.url}
-                width={imageFields?.file?.details?.image?.width}
-                height={imageFields?.file?.details?.image?.height}
-              />
+              <div css={logoContainer}>
+                <img
+                  key={sys.id}
+                  alt={imageFields?.description}
+                  src={imageFields?.file?.url}
+                  width={imageFields?.file?.details?.image?.width}
+                  height={imageFields?.file?.details?.image?.height}
+                />
+                <p css={logoTitle}>{item.title}</p>
+              </div>
             )
 
             if (item.url) {
@@ -63,6 +66,17 @@ export const ROW = {
   ),
 }
 
-const rootStyle = css(flexRow,  {
-  flexWrap: "wrap"
+const rootStyle = css(flexRow, {
+  flexWrap: "wrap",
+})
+
+const logoContainer = css(flexRow, {
+  alignItems: "center",
+  marginLeft: 12,
+  marginRight: 12,
+})
+
+const logoTitle = css({
+  fontSize: 16,
+  fontWeight: 500,
 })

--- a/src/utils/contentful.ts
+++ b/src/utils/contentful.ts
@@ -210,6 +210,7 @@ export interface ContentfulPage<T> {
 export interface GalleryItem {
   url: string
   image: Asset
+  title: string
 }
 
 export interface LogoGallery {

--- a/src/utils/contentful.ts
+++ b/src/utils/contentful.ts
@@ -210,7 +210,7 @@ export interface ContentfulPage<T> {
 export interface GalleryItem {
   url: string
   image: Asset
-  title: string
+  title?: string
 }
 
 export interface LogoGallery {


### PR DESCRIPTION
**Description**

Reimplemented the images for the icons and brand name in to the celo.org/dapps in the *Celo assets also available in crypto exchange wallets including* section.

<img width="911" alt="Screen Shot 2021-10-05 at 1 00 11 PM" src="https://user-images.githubusercontent.com/55670305/136069634-0f7c9bb9-2851-45ad-a680-989a83c5b95e.png">

issue #356 

