### PR TITLE
Fix green coin not showing on Ecosystem in Navigation 

### DIFF
--- a/src/header/Navigation.tsx
+++ b/src/header/Navigation.tsx
@@ -238,7 +238,7 @@ const NavigationLinks = React.memo(function _NavigationLinks(props: {
 }) {
   const { t } = useTranslation(NameSpaces.common)
   const foregroundColor = props.isDarkMode ? colors.white : colors.dark
-  const { pathname } = useRouter()
+  const { pathname, asPath } = useRouter()
 
   return (
     <nav
@@ -255,12 +255,12 @@ const NavigationLinks = React.memo(function _NavigationLinks(props: {
             href={item.link}
             text={t(item.name)}
           />
-          {pathname === item.link && (
+          {pathname === item.link || asPath === item.link && (
             <div css={styles.activeTab}>
               <OvalCoin color={colors.primary} size={10} />
             </div>
           )}
-        </div>
+          </div>
       ))}
       <div css={styles.linkWrapper}>
         <Button


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12700801/144686250-ad95016d-b327-42f9-ba3b-ddc3a3c3197d.png)
Includes "asPath" from useRouter to match Ecosystem page in the nav bar 
fixes #487 