### PR TITLE
Make edits on BrandKit for Key Imagery page 

### DIFF
--- a/pages/experience/brand/key-imagery.tsx
+++ b/pages/experience/brand/key-imagery.tsx
@@ -5,10 +5,8 @@ import makeSafeForJson from "src/utils/makeSafeForJson"
 
 export async function getServerSideProps() {
   const AssetBase = await import("src/../server/AssetBase")
-  const [illos] = await Promise.all([
-    AssetBase.default(AssetBase.AssetSheet.Illustrations),
-  ])
-
+  const illos = await AssetBase.default(AssetBase.AssetSheet.Illustrations)
+  
   return {
     props: makeSafeForJson({
       illos,

--- a/pages/experience/brand/key-imagery.tsx
+++ b/pages/experience/brand/key-imagery.tsx
@@ -5,15 +5,13 @@ import makeSafeForJson from "src/utils/makeSafeForJson"
 
 export async function getServerSideProps() {
   const AssetBase = await import("src/../server/AssetBase")
-  const [illos, graphics] = await Promise.all([
+  const [illos] = await Promise.all([
     AssetBase.default(AssetBase.AssetSheet.Illustrations),
-    AssetBase.default(AssetBase.AssetSheet.AbstractGraphics),
   ])
 
   return {
     props: makeSafeForJson({
       illos,
-      graphics,
       ...(await serverSideTranslations("en", [NameSpaces.common, NameSpaces.brand])),
     }),
   }

--- a/public/locales/en/brand.json
+++ b/public/locales/en/brand.json
@@ -96,7 +96,6 @@
     "headline": "Used to tell a story, key images are visual tools that bring the text to life. These images help the user comprehend the material multidimensionally.\n\nImages have descriptions that act as guidelines for both accessibility and communication clarity. Most images can have multiple meanings and we encourage the Celo community to find new culturally appropriate applications for them.",
     "license": "You may copy and redistribute illustrations and abstract graphics as long as you are abiding by the <0>Brand Policy</0>. You may not remix or transform them.",
     "illoTitle": "Illustrations",
-    "illoText": "Illustrations show concrete ways that humans interact with an idea. They utilize current mental models to simplify a concept.",
     "abstractTitle": "Abstract Graphics",
     "abstractText": "Abstract Graphics are visual tools that use coins to animate an idea. They can be dynamic or static."
   },

--- a/src/_page-tests/experience/__snapshots__/color.test.tsx.snap
+++ b/src/_page-tests/experience/__snapshots__/color.test.tsx.snap
@@ -331,7 +331,7 @@ exports[`Experience/Color renders 1`] = `
   transition-duration: 500ms;
 }
 
-.emotion-92 {
+.emotion-91 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -353,7 +353,7 @@ exports[`Experience/Color renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-92 {
+  .emotion-91 {
     z-index: -5;
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
@@ -363,18 +363,18 @@ exports[`Experience/Color renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-92 {
+  .emotion-91 {
     max-width: 958px;
   }
 }
 
 @media (min-width: 992px) {
-  .emotion-92 {
+  .emotion-91 {
     max-width: 1080px;
   }
 }
 
-.emotion-93 {
+.emotion-92 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -393,12 +393,12 @@ exports[`Experience/Color renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-93 {
+  .emotion-92 {
     display: none;
   }
 }
 
-.emotion-149 {
+.emotion-147 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -411,7 +411,7 @@ exports[`Experience/Color renders 1`] = `
 }
 
 @media (min-width: 576px) {
-  .emotion-149 {
+  .emotion-147 {
     -webkit-flex: 1;
     -ms-flex: 1;
     flex: 1;
@@ -422,7 +422,7 @@ exports[`Experience/Color renders 1`] = `
   }
 }
 
-.emotion-150 {
+.emotion-148 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -436,7 +436,7 @@ exports[`Experience/Color renders 1`] = `
 }
 
 @media (min-width: 576px) {
-  .emotion-150 {
+  .emotion-148 {
     -webkit-transform: translateY(-25);
     -moz-transform: translateY(-25);
     -ms-transform: translateY(-25);
@@ -444,7 +444,7 @@ exports[`Experience/Color renders 1`] = `
   }
 }
 
-.emotion-151 {
+.emotion-149 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -455,7 +455,7 @@ exports[`Experience/Color renders 1`] = `
   flex-direction: column;
 }
 
-.emotion-362 {
+.emotion-360 {
   margin-top: 20px;
   padding-top: 10px;
   padding-bottom: 10px;
@@ -464,17 +464,17 @@ exports[`Experience/Color renders 1`] = `
   flex: 1;
 }
 
-.emotion-363 {
+.emotion-361 {
   margin: 5px 0px;
 }
 
-.emotion-392 {
+.emotion-390 {
   z-index: -10;
   background-color: #FFFFFF;
   margin-top: 50px;
 }
 
-.emotion-393 {
+.emotion-391 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -494,7 +494,7 @@ exports[`Experience/Color renders 1`] = `
   width: 100%;
 }
 
-.emotion-394 {
+.emotion-392 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -523,7 +523,7 @@ exports[`Experience/Color renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-394 {
+  .emotion-392 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -540,7 +540,7 @@ exports[`Experience/Color renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-394 {
+  .emotion-392 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -552,36 +552,36 @@ exports[`Experience/Color renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-394 {
+  .emotion-392 {
     grid-template-columns: 1fr 1fr 1fr;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-394 {
+  .emotion-392 {
     grid-template-columns: 1fr 1fr 1fr;
   }
 }
 
 @media (min-width: 992px) {
-  .emotion-394 {
+  .emotion-392 {
     margin-top: 60px;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-394 {
+  .emotion-392 {
     margin-top: 40px;
   }
 }
 
 @media (max-width: 576px) {
-  .emotion-394 {
+  .emotion-392 {
     margin-top: 30px;
   }
 }
 
-.emotion-395 {
+.emotion-393 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -594,12 +594,12 @@ exports[`Experience/Color renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-395 {
+  .emotion-393 {
     grid-column: span 3;
   }
 }
 
-.emotion-396 {
+.emotion-394 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -612,7 +612,7 @@ exports[`Experience/Color renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-396 {
+  .emotion-394 {
     margin-bottom: 30px;
     -webkit-box-pack: center;
     -ms-flex-pack: center;
@@ -625,7 +625,7 @@ exports[`Experience/Color renders 1`] = `
   }
 }
 
-.emotion-397 {
+.emotion-395 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -638,7 +638,7 @@ exports[`Experience/Color renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-397 {
+  .emotion-395 {
     -webkit-box-pack: center;
     -ms-flex-pack: center;
     -webkit-justify-content: center;
@@ -650,7 +650,7 @@ exports[`Experience/Color renders 1`] = `
   }
 }
 
-.emotion-398 {
+.emotion-396 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -667,16 +667,16 @@ exports[`Experience/Color renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-398 {
+  .emotion-396 {
     text-align: center;
   }
 }
 
-.emotion-400 {
+.emotion-398 {
   color: inherit;
 }
 
-.emotion-401 {
+.emotion-399 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -689,12 +689,12 @@ exports[`Experience/Color renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-401 {
+  .emotion-399 {
     grid-column: span 3;
   }
 }
 
-.emotion-402 {
+.emotion-400 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -710,21 +710,21 @@ exports[`Experience/Color renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-402 {
+  .emotion-400 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     justify-content: space-between;
   }
 }
 
-.emotion-403 {
+.emotion-401 {
   padding-left: 25px;
   padding-right: 25px;
   padding-start: 0;
 }
 
 @media (max-width: 576px) {
-  .emotion-403 {
+  .emotion-401 {
     margin-top: 35px;
     width: 50%;
     padding-left: 10px;
@@ -732,7 +732,7 @@ exports[`Experience/Color renders 1`] = `
   }
 }
 
-.emotion-404 {
+.emotion-402 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -747,18 +747,18 @@ exports[`Experience/Color renders 1`] = `
   margin-bottom: 20px;
 }
 
-.emotion-405 {
+.emotion-403 {
   margin-top: 8px;
   margin-bottom: 8px;
 }
 
-.emotion-445 {
+.emotion-443 {
   padding-left: 25px;
   padding-right: 25px;
 }
 
 @media (max-width: 576px) {
-  .emotion-445 {
+  .emotion-443 {
     margin-top: 35px;
     width: 50%;
     padding-left: 10px;
@@ -766,14 +766,14 @@ exports[`Experience/Color renders 1`] = `
   }
 }
 
-.emotion-519 {
+.emotion-517 {
   padding-left: 25px;
   padding-right: 25px;
   padding-end: 0;
 }
 
 @media (max-width: 576px) {
-  .emotion-519 {
+  .emotion-517 {
     margin-top: 35px;
     width: 50%;
     padding-left: 10px;
@@ -781,7 +781,7 @@ exports[`Experience/Color renders 1`] = `
   }
 }
 
-.emotion-588 {
+.emotion-586 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -810,7 +810,7 @@ exports[`Experience/Color renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-588 {
+  .emotion-586 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -827,7 +827,7 @@ exports[`Experience/Color renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-588 {
+  .emotion-586 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -839,39 +839,39 @@ exports[`Experience/Color renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-588 {
+  .emotion-586 {
     grid-template-columns: 1fr;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-588 {
+  .emotion-586 {
     grid-template-columns: 1fr;
   }
 }
 
 @media (min-width: 992px) {
-  .emotion-588 {
+  .emotion-586 {
     margin-top: 60px;
     margin-bottom: 60px;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-588 {
+  .emotion-586 {
     margin-top: 40px;
     margin-bottom: 40px;
   }
 }
 
 @media (max-width: 576px) {
-  .emotion-588 {
+  .emotion-586 {
     margin-top: 30px;
     margin-bottom: 30px;
   }
 }
 
-.emotion-589 {
+.emotion-587 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -889,7 +889,7 @@ exports[`Experience/Color renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-589 {
+  .emotion-587 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -904,7 +904,7 @@ exports[`Experience/Color renders 1`] = `
   }
 }
 
-.emotion-590 {
+.emotion-588 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -918,7 +918,7 @@ exports[`Experience/Color renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-590 {
+  .emotion-588 {
     -webkit-box-pack: center;
     -ms-flex-pack: center;
     -webkit-justify-content: center;
@@ -930,31 +930,31 @@ exports[`Experience/Color renders 1`] = `
   }
 }
 
-.emotion-591 {
+.emotion-589 {
   width: 20px;
   height: 20px;
   z-index: 10;
 }
 
 @media (max-width: 576px) {
-  .emotion-591 {
+  .emotion-589 {
     margin-bottom: 8px;
   }
 }
 
-.emotion-592 {
+.emotion-590 {
   margin-left: 10px;
   margin-right: 10px;
   z-index: 10;
 }
 
 @media (max-width: 576px) {
-  .emotion-592 {
+  .emotion-590 {
     display: none;
   }
 }
 
-.emotion-593 {
+.emotion-591 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -966,7 +966,7 @@ exports[`Experience/Color renders 1`] = `
   position: relative;
 }
 
-.emotion-594 {
+.emotion-592 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -993,7 +993,7 @@ exports[`Experience/Color renders 1`] = `
   animation-name: animation-0;
 }
 
-.emotion-595 {
+.emotion-593 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -1016,12 +1016,12 @@ exports[`Experience/Color renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-595 {
+  .emotion-593 {
     text-align: center;
   }
 }
 
-.emotion-596 {
+.emotion-594 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1046,7 +1046,7 @@ exports[`Experience/Color renders 1`] = `
   animation-name: animation-2;
 }
 
-.emotion-597 {
+.emotion-595 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -2154,19 +2154,16 @@ exports[`Experience/Color renders 1`] = `
                 Key Imagery
               </a>
             </div>
-            <div
-              className="emotion-44"
-            />
           </div>
         </div>
       </div>
     </div>
   </div>
   <div
-    className="emotion-92"
+    className="emotion-91"
   >
     <div
-      className="emotion-93"
+      className="emotion-92"
     >
       <div
         className="emotion-37"
@@ -2819,19 +2816,16 @@ exports[`Experience/Color renders 1`] = `
             Key Imagery
           </a>
         </div>
-        <div
-          className="emotion-44"
-        />
       </div>
     </div>
     <div
-      className="emotion-149"
+      className="emotion-147"
     >
       <div
-        className="emotion-150"
+        className="emotion-148"
       >
         <div
-          className="emotion-151"
+          className="emotion-149"
           id="overview"
         >
           <div
@@ -5355,7 +5349,7 @@ Blue represents help within digital experiences like websites and mobile applica
           </div>
         </div>
         <div
-          className="emotion-151"
+          className="emotion-149"
           id="background-colors"
         >
           <div
@@ -6385,10 +6379,10 @@ Blue represents help within digital experiences like websites and mobile applica
                 }
               >
                 <div
-                  className="emotion-362"
+                  className="emotion-360"
                 >
                   <img
-                    className="emotion-363"
+                    className="emotion-361"
                     height={24}
                     src="/image.png"
                     width={24}
@@ -6435,10 +6429,10 @@ Blue represents help within digital experiences like websites and mobile applica
                   </div>
                 </div>
                 <div
-                  className="emotion-362"
+                  className="emotion-360"
                 >
                   <img
-                    className="emotion-363"
+                    className="emotion-361"
                     height={24}
                     src="/image.png"
                     width={24}
@@ -6498,10 +6492,10 @@ Blue represents help within digital experiences like websites and mobile applica
                 }
               >
                 <div
-                  className="emotion-362"
+                  className="emotion-360"
                 >
                   <img
-                    className="emotion-363"
+                    className="emotion-361"
                     height={24}
                     src="/image.png"
                     width={24}
@@ -6587,10 +6581,10 @@ Blue represents help within digital experiences like websites and mobile applica
                   </div>
                 </div>
                 <div
-                  className="emotion-362"
+                  className="emotion-360"
                 >
                   <img
-                    className="emotion-363"
+                    className="emotion-361"
                     height={24}
                     src="/image.png"
                     width={24}
@@ -6689,10 +6683,10 @@ Blue represents help within digital experiences like websites and mobile applica
                 }
               >
                 <div
-                  className="emotion-362"
+                  className="emotion-360"
                 >
                   <img
-                    className="emotion-363"
+                    className="emotion-361"
                     height={24}
                     src="/image.png"
                     width={24}
@@ -6739,10 +6733,10 @@ Blue represents help within digital experiences like websites and mobile applica
                   </div>
                 </div>
                 <div
-                  className="emotion-362"
+                  className="emotion-360"
                 >
                   <img
-                    className="emotion-363"
+                    className="emotion-361"
                     height={24}
                     src="/image.png"
                     width={24}
@@ -6796,20 +6790,20 @@ Blue represents help within digital experiences like websites and mobile applica
     </div>
   </div>
   <div
-    className="emotion-392"
+    className="emotion-390"
     id="experience-footer"
   >
     <section
-      className="emotion-393"
+      className="emotion-391"
     >
       <div
-        className="emotion-394"
+        className="emotion-392"
       >
         <div
-          className="emotion-395"
+          className="emotion-393"
         >
           <div
-            className="emotion-396"
+            className="emotion-394"
           >
             <svg
               fill="none"
@@ -6832,19 +6826,19 @@ Blue represents help within digital experiences like websites and mobile applica
             </svg>
           </div>
           <div
-            className="emotion-397"
+            className="emotion-395"
           >
             <p
-              className="emotion-398"
+              className="emotion-396"
             >
               Nothing herein constitutes an offer to sell, or the solicitation of an offer to buy, any securities or tokens.
             </p>
             <p
-              className="emotion-398"
+              className="emotion-396"
             >
               Read more in Celo 
               <a
-                className="emotion-400"
+                className="emotion-398"
                 href="/terms"
               >
                 Terms of Service
@@ -6853,21 +6847,21 @@ Blue represents help within digital experiences like websites and mobile applica
           </div>
         </div>
         <div
-          className="emotion-401"
+          className="emotion-399"
         >
           <div
-            className="emotion-402"
+            className="emotion-400"
           >
             <div
-              className="emotion-403"
+              className="emotion-401"
             >
               <h6
-                className="emotion-404"
+                className="emotion-402"
               >
                 Celo
               </h6>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -6916,7 +6910,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -6965,7 +6959,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -7014,7 +7008,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -7063,7 +7057,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -7112,7 +7106,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -7161,7 +7155,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -7210,7 +7204,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -7260,15 +7254,15 @@ Blue represents help within digital experiences like websites and mobile applica
               </div>
             </div>
             <div
-              className="emotion-445"
+              className="emotion-443"
             >
               <h6
-                className="emotion-404"
+                className="emotion-402"
               >
                 Technology
               </h6>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -7317,7 +7311,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -7366,7 +7360,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -7415,7 +7409,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -7464,7 +7458,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -7514,15 +7508,15 @@ Blue represents help within digital experiences like websites and mobile applica
               </div>
             </div>
             <div
-              className="emotion-445"
+              className="emotion-443"
             >
               <h6
-                className="emotion-404"
+                className="emotion-402"
               >
                 Resources
               </h6>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -7571,7 +7565,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -7620,7 +7614,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -7669,7 +7663,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -7718,7 +7712,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -7767,7 +7761,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -7816,7 +7810,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -7865,7 +7859,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -7914,7 +7908,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -7964,15 +7958,15 @@ Blue represents help within digital experiences like websites and mobile applica
               </div>
             </div>
             <div
-              className="emotion-519"
+              className="emotion-517"
             >
               <h6
-                className="emotion-404"
+                className="emotion-402"
               >
                 Social
               </h6>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -8045,7 +8039,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -8120,7 +8114,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -8193,7 +8187,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -8266,7 +8260,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -8341,7 +8335,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -8414,7 +8408,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -8486,7 +8480,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -8556,7 +8550,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -8626,7 +8620,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -8696,7 +8690,7 @@ Blue represents help within digital experiences like websites and mobile applica
                 </div>
               </div>
               <div
-                className="emotion-405"
+                className="emotion-403"
               >
                 <div
                   className="emotion-11"
@@ -8771,48 +8765,48 @@ Blue represents help within digital experiences like websites and mobile applica
       </div>
     </section>
     <section
-      className="emotion-393"
+      className="emotion-391"
     >
       <div
-        className="emotion-588"
+        className="emotion-586"
       >
         <div
-          className="emotion-589"
+          className="emotion-587"
         >
           <div
-            className="emotion-590"
+            className="emotion-588"
           >
             <img
-              className="emotion-591"
+              className="emotion-589"
               height={100}
               src="/image.png"
               width={100}
             />
             <span
-              className="emotion-592"
+              className="emotion-590"
             >
               |
             </span>
             <div
-              className="emotion-593"
+              className="emotion-591"
             >
               <div
-                className="emotion-594"
+                className="emotion-592"
               />
               <span
-                className="emotion-595"
+                className="emotion-593"
               >
                 "
                 Change the Story
                 "
               </span>
               <div
-                className="emotion-596"
+                className="emotion-594"
               />
             </div>
           </div>
           <small
-            className="emotion-597"
+            className="emotion-595"
           >
             The Celo Foundation, © Celo 2021
           </small>

--- a/src/_page-tests/experience/__snapshots__/composition.test.tsx.snap
+++ b/src/_page-tests/experience/__snapshots__/composition.test.tsx.snap
@@ -331,7 +331,7 @@ exports[`Experience/Composition renders 1`] = `
   transition-duration: 500ms;
 }
 
-.emotion-92 {
+.emotion-91 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -353,7 +353,7 @@ exports[`Experience/Composition renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-92 {
+  .emotion-91 {
     z-index: -5;
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
@@ -363,18 +363,18 @@ exports[`Experience/Composition renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-92 {
+  .emotion-91 {
     max-width: 958px;
   }
 }
 
 @media (min-width: 992px) {
-  .emotion-92 {
+  .emotion-91 {
     max-width: 1080px;
   }
 }
 
-.emotion-93 {
+.emotion-92 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -393,12 +393,12 @@ exports[`Experience/Composition renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-93 {
+  .emotion-92 {
     display: none;
   }
 }
 
-.emotion-149 {
+.emotion-147 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -411,7 +411,7 @@ exports[`Experience/Composition renders 1`] = `
 }
 
 @media (min-width: 576px) {
-  .emotion-149 {
+  .emotion-147 {
     -webkit-flex: 1;
     -ms-flex: 1;
     flex: 1;
@@ -422,7 +422,7 @@ exports[`Experience/Composition renders 1`] = `
   }
 }
 
-.emotion-150 {
+.emotion-148 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -436,7 +436,7 @@ exports[`Experience/Composition renders 1`] = `
 }
 
 @media (min-width: 576px) {
-  .emotion-150 {
+  .emotion-148 {
     -webkit-transform: translateY(-25);
     -moz-transform: translateY(-25);
     -ms-transform: translateY(-25);
@@ -444,7 +444,7 @@ exports[`Experience/Composition renders 1`] = `
   }
 }
 
-.emotion-151 {
+.emotion-149 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -455,13 +455,13 @@ exports[`Experience/Composition renders 1`] = `
   flex-direction: column;
 }
 
-.emotion-218 {
+.emotion-216 {
   z-index: -10;
   background-color: #FFFFFF;
   margin-top: 50px;
 }
 
-.emotion-219 {
+.emotion-217 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -481,7 +481,7 @@ exports[`Experience/Composition renders 1`] = `
   width: 100%;
 }
 
-.emotion-220 {
+.emotion-218 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -510,7 +510,7 @@ exports[`Experience/Composition renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-220 {
+  .emotion-218 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -527,7 +527,7 @@ exports[`Experience/Composition renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-220 {
+  .emotion-218 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -539,36 +539,36 @@ exports[`Experience/Composition renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-220 {
+  .emotion-218 {
     grid-template-columns: 1fr 1fr 1fr;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-220 {
+  .emotion-218 {
     grid-template-columns: 1fr 1fr 1fr;
   }
 }
 
 @media (min-width: 992px) {
-  .emotion-220 {
+  .emotion-218 {
     margin-top: 60px;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-220 {
+  .emotion-218 {
     margin-top: 40px;
   }
 }
 
 @media (max-width: 576px) {
-  .emotion-220 {
+  .emotion-218 {
     margin-top: 30px;
   }
 }
 
-.emotion-221 {
+.emotion-219 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -581,12 +581,12 @@ exports[`Experience/Composition renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-221 {
+  .emotion-219 {
     grid-column: span 3;
   }
 }
 
-.emotion-222 {
+.emotion-220 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -599,7 +599,7 @@ exports[`Experience/Composition renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-222 {
+  .emotion-220 {
     margin-bottom: 30px;
     -webkit-box-pack: center;
     -ms-flex-pack: center;
@@ -612,7 +612,7 @@ exports[`Experience/Composition renders 1`] = `
   }
 }
 
-.emotion-223 {
+.emotion-221 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -625,7 +625,7 @@ exports[`Experience/Composition renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-223 {
+  .emotion-221 {
     -webkit-box-pack: center;
     -ms-flex-pack: center;
     -webkit-justify-content: center;
@@ -637,7 +637,7 @@ exports[`Experience/Composition renders 1`] = `
   }
 }
 
-.emotion-224 {
+.emotion-222 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -654,16 +654,16 @@ exports[`Experience/Composition renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-224 {
+  .emotion-222 {
     text-align: center;
   }
 }
 
-.emotion-226 {
+.emotion-224 {
   color: inherit;
 }
 
-.emotion-227 {
+.emotion-225 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -676,12 +676,12 @@ exports[`Experience/Composition renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-227 {
+  .emotion-225 {
     grid-column: span 3;
   }
 }
 
-.emotion-228 {
+.emotion-226 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -697,21 +697,21 @@ exports[`Experience/Composition renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-228 {
+  .emotion-226 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     justify-content: space-between;
   }
 }
 
-.emotion-229 {
+.emotion-227 {
   padding-left: 25px;
   padding-right: 25px;
   padding-start: 0;
 }
 
 @media (max-width: 576px) {
-  .emotion-229 {
+  .emotion-227 {
     margin-top: 35px;
     width: 50%;
     padding-left: 10px;
@@ -719,7 +719,7 @@ exports[`Experience/Composition renders 1`] = `
   }
 }
 
-.emotion-230 {
+.emotion-228 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -734,18 +734,18 @@ exports[`Experience/Composition renders 1`] = `
   margin-bottom: 20px;
 }
 
-.emotion-231 {
+.emotion-229 {
   margin-top: 8px;
   margin-bottom: 8px;
 }
 
-.emotion-271 {
+.emotion-269 {
   padding-left: 25px;
   padding-right: 25px;
 }
 
 @media (max-width: 576px) {
-  .emotion-271 {
+  .emotion-269 {
     margin-top: 35px;
     width: 50%;
     padding-left: 10px;
@@ -753,14 +753,14 @@ exports[`Experience/Composition renders 1`] = `
   }
 }
 
-.emotion-345 {
+.emotion-343 {
   padding-left: 25px;
   padding-right: 25px;
   padding-end: 0;
 }
 
 @media (max-width: 576px) {
-  .emotion-345 {
+  .emotion-343 {
     margin-top: 35px;
     width: 50%;
     padding-left: 10px;
@@ -768,7 +768,7 @@ exports[`Experience/Composition renders 1`] = `
   }
 }
 
-.emotion-414 {
+.emotion-412 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -797,7 +797,7 @@ exports[`Experience/Composition renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-414 {
+  .emotion-412 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -814,7 +814,7 @@ exports[`Experience/Composition renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-414 {
+  .emotion-412 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -826,39 +826,39 @@ exports[`Experience/Composition renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-414 {
+  .emotion-412 {
     grid-template-columns: 1fr;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-414 {
+  .emotion-412 {
     grid-template-columns: 1fr;
   }
 }
 
 @media (min-width: 992px) {
-  .emotion-414 {
+  .emotion-412 {
     margin-top: 60px;
     margin-bottom: 60px;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-414 {
+  .emotion-412 {
     margin-top: 40px;
     margin-bottom: 40px;
   }
 }
 
 @media (max-width: 576px) {
-  .emotion-414 {
+  .emotion-412 {
     margin-top: 30px;
     margin-bottom: 30px;
   }
 }
 
-.emotion-415 {
+.emotion-413 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -876,7 +876,7 @@ exports[`Experience/Composition renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-415 {
+  .emotion-413 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -891,7 +891,7 @@ exports[`Experience/Composition renders 1`] = `
   }
 }
 
-.emotion-416 {
+.emotion-414 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -905,7 +905,7 @@ exports[`Experience/Composition renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-416 {
+  .emotion-414 {
     -webkit-box-pack: center;
     -ms-flex-pack: center;
     -webkit-justify-content: center;
@@ -917,31 +917,31 @@ exports[`Experience/Composition renders 1`] = `
   }
 }
 
-.emotion-417 {
+.emotion-415 {
   width: 20px;
   height: 20px;
   z-index: 10;
 }
 
 @media (max-width: 576px) {
-  .emotion-417 {
+  .emotion-415 {
     margin-bottom: 8px;
   }
 }
 
-.emotion-418 {
+.emotion-416 {
   margin-left: 10px;
   margin-right: 10px;
   z-index: 10;
 }
 
 @media (max-width: 576px) {
-  .emotion-418 {
+  .emotion-416 {
     display: none;
   }
 }
 
-.emotion-419 {
+.emotion-417 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -953,7 +953,7 @@ exports[`Experience/Composition renders 1`] = `
   position: relative;
 }
 
-.emotion-420 {
+.emotion-418 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -980,7 +980,7 @@ exports[`Experience/Composition renders 1`] = `
   animation-name: animation-0;
 }
 
-.emotion-421 {
+.emotion-419 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -1003,12 +1003,12 @@ exports[`Experience/Composition renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-421 {
+  .emotion-419 {
     text-align: center;
   }
 }
 
-.emotion-422 {
+.emotion-420 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1033,7 +1033,7 @@ exports[`Experience/Composition renders 1`] = `
   animation-name: animation-2;
 }
 
-.emotion-423 {
+.emotion-421 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -2141,19 +2141,16 @@ exports[`Experience/Composition renders 1`] = `
                 Key Imagery
               </a>
             </div>
-            <div
-              className="emotion-44"
-            />
           </div>
         </div>
       </div>
     </div>
   </div>
   <div
-    className="emotion-92"
+    className="emotion-91"
   >
     <div
-      className="emotion-93"
+      className="emotion-92"
     >
       <div
         className="emotion-37"
@@ -2806,19 +2803,16 @@ exports[`Experience/Composition renders 1`] = `
             Key Imagery
           </a>
         </div>
-        <div
-          className="emotion-44"
-        />
       </div>
     </div>
     <div
-      className="emotion-149"
+      className="emotion-147"
     >
       <div
-        className="emotion-150"
+        className="emotion-148"
       >
         <div
-          className="emotion-151"
+          className="emotion-149"
           id="overview"
         >
           <div
@@ -3417,7 +3411,7 @@ exports[`Experience/Composition renders 1`] = `
           </div>
         </div>
         <div
-          className="emotion-151"
+          className="emotion-149"
           id="grid"
         >
           <div
@@ -3984,20 +3978,20 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
     </div>
   </div>
   <div
-    className="emotion-218"
+    className="emotion-216"
     id="experience-footer"
   >
     <section
-      className="emotion-219"
+      className="emotion-217"
     >
       <div
-        className="emotion-220"
+        className="emotion-218"
       >
         <div
-          className="emotion-221"
+          className="emotion-219"
         >
           <div
-            className="emotion-222"
+            className="emotion-220"
           >
             <svg
               fill="none"
@@ -4020,19 +4014,19 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
             </svg>
           </div>
           <div
-            className="emotion-223"
+            className="emotion-221"
           >
             <p
-              className="emotion-224"
+              className="emotion-222"
             >
               Nothing herein constitutes an offer to sell, or the solicitation of an offer to buy, any securities or tokens.
             </p>
             <p
-              className="emotion-224"
+              className="emotion-222"
             >
               Read more in Celo 
               <a
-                className="emotion-226"
+                className="emotion-224"
                 href="/terms"
               >
                 Terms of Service
@@ -4041,21 +4035,21 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
           </div>
         </div>
         <div
-          className="emotion-227"
+          className="emotion-225"
         >
           <div
-            className="emotion-228"
+            className="emotion-226"
           >
             <div
-              className="emotion-229"
+              className="emotion-227"
             >
               <h6
-                className="emotion-230"
+                className="emotion-228"
               >
                 Celo
               </h6>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -4104,7 +4098,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -4153,7 +4147,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -4202,7 +4196,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -4251,7 +4245,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -4300,7 +4294,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -4349,7 +4343,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -4398,7 +4392,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -4448,15 +4442,15 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
               </div>
             </div>
             <div
-              className="emotion-271"
+              className="emotion-269"
             >
               <h6
-                className="emotion-230"
+                className="emotion-228"
               >
                 Technology
               </h6>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -4505,7 +4499,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -4554,7 +4548,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -4603,7 +4597,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -4652,7 +4646,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -4702,15 +4696,15 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
               </div>
             </div>
             <div
-              className="emotion-271"
+              className="emotion-269"
             >
               <h6
-                className="emotion-230"
+                className="emotion-228"
               >
                 Resources
               </h6>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -4759,7 +4753,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -4808,7 +4802,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -4857,7 +4851,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -4906,7 +4900,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -4955,7 +4949,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -5004,7 +4998,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -5053,7 +5047,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -5102,7 +5096,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -5152,15 +5146,15 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
               </div>
             </div>
             <div
-              className="emotion-345"
+              className="emotion-343"
             >
               <h6
-                className="emotion-230"
+                className="emotion-228"
               >
                 Social
               </h6>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -5233,7 +5227,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -5308,7 +5302,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -5381,7 +5375,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -5454,7 +5448,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -5529,7 +5523,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -5602,7 +5596,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -5674,7 +5668,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -5744,7 +5738,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -5814,7 +5808,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -5884,7 +5878,7 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
                 </div>
               </div>
               <div
-                className="emotion-231"
+                className="emotion-229"
               >
                 <div
                   className="emotion-11"
@@ -5959,48 +5953,48 @@ Between each section of the grid, there is a gutter that organizes the hierarchy
       </div>
     </section>
     <section
-      className="emotion-219"
+      className="emotion-217"
     >
       <div
-        className="emotion-414"
+        className="emotion-412"
       >
         <div
-          className="emotion-415"
+          className="emotion-413"
         >
           <div
-            className="emotion-416"
+            className="emotion-414"
           >
             <img
-              className="emotion-417"
+              className="emotion-415"
               height={100}
               src="/image.png"
               width={100}
             />
             <span
-              className="emotion-418"
+              className="emotion-416"
             >
               |
             </span>
             <div
-              className="emotion-419"
+              className="emotion-417"
             >
               <div
-                className="emotion-420"
+                className="emotion-418"
               />
               <span
-                className="emotion-421"
+                className="emotion-419"
               >
                 "
                 Change the Story
                 "
               </span>
               <div
-                className="emotion-422"
+                className="emotion-420"
               />
             </div>
           </div>
           <small
-            className="emotion-423"
+            className="emotion-421"
           >
             The Celo Foundation, © Celo 2021
           </small>

--- a/src/_page-tests/experience/__snapshots__/exchange-icons.test.tsx.snap
+++ b/src/_page-tests/experience/__snapshots__/exchange-icons.test.tsx.snap
@@ -331,7 +331,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
   transition-duration: 500ms;
 }
 
-.emotion-92 {
+.emotion-91 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -353,7 +353,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-92 {
+  .emotion-91 {
     z-index: -5;
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
@@ -363,18 +363,18 @@ exports[`Experience/ExchangeIcons renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-92 {
+  .emotion-91 {
     max-width: 958px;
   }
 }
 
 @media (min-width: 992px) {
-  .emotion-92 {
+  .emotion-91 {
     max-width: 1080px;
   }
 }
 
-.emotion-93 {
+.emotion-92 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -393,12 +393,12 @@ exports[`Experience/ExchangeIcons renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-93 {
+  .emotion-92 {
     display: none;
   }
 }
 
-.emotion-149 {
+.emotion-147 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -411,7 +411,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
 }
 
 @media (min-width: 576px) {
-  .emotion-149 {
+  .emotion-147 {
     -webkit-flex: 1;
     -ms-flex: 1;
     flex: 1;
@@ -422,7 +422,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
   }
 }
 
-.emotion-150 {
+.emotion-148 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -436,7 +436,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
 }
 
 @media (min-width: 576px) {
-  .emotion-150 {
+  .emotion-148 {
     -webkit-transform: translateY(-25);
     -moz-transform: translateY(-25);
     -ms-transform: translateY(-25);
@@ -444,7 +444,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
   }
 }
 
-.emotion-151 {
+.emotion-149 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -455,7 +455,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
   flex-direction: column;
 }
 
-.emotion-152 {
+.emotion-150 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -468,16 +468,16 @@ exports[`Experience/ExchangeIcons renders 1`] = `
   padding-right: 10px;
 }
 
-.emotion-153 {
+.emotion-151 {
   margin-left: 10px;
   margin-right: 10px;
 }
 
-.emotion-170 {
+.emotion-168 {
   min-height: 75vh;
 }
 
-.emotion-171 {
+.emotion-169 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -492,17 +492,17 @@ exports[`Experience/ExchangeIcons renders 1`] = `
   flex-wrap: wrap;
 }
 
-.emotion-173 {
+.emotion-171 {
   opacity: 0;
 }
 
-.emotion-352 {
+.emotion-350 {
   z-index: -10;
   background-color: #FFFFFF;
   margin-top: 50px;
 }
 
-.emotion-353 {
+.emotion-351 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -522,7 +522,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
   width: 100%;
 }
 
-.emotion-354 {
+.emotion-352 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -551,7 +551,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-354 {
+  .emotion-352 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -568,7 +568,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-354 {
+  .emotion-352 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -580,36 +580,36 @@ exports[`Experience/ExchangeIcons renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-354 {
+  .emotion-352 {
     grid-template-columns: 1fr 1fr 1fr;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-354 {
+  .emotion-352 {
     grid-template-columns: 1fr 1fr 1fr;
   }
 }
 
 @media (min-width: 992px) {
-  .emotion-354 {
+  .emotion-352 {
     margin-top: 60px;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-354 {
+  .emotion-352 {
     margin-top: 40px;
   }
 }
 
 @media (max-width: 576px) {
-  .emotion-354 {
+  .emotion-352 {
     margin-top: 30px;
   }
 }
 
-.emotion-355 {
+.emotion-353 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -622,12 +622,12 @@ exports[`Experience/ExchangeIcons renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-355 {
+  .emotion-353 {
     grid-column: span 3;
   }
 }
 
-.emotion-356 {
+.emotion-354 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -640,7 +640,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-356 {
+  .emotion-354 {
     margin-bottom: 30px;
     -webkit-box-pack: center;
     -ms-flex-pack: center;
@@ -653,7 +653,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
   }
 }
 
-.emotion-357 {
+.emotion-355 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -666,7 +666,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-357 {
+  .emotion-355 {
     -webkit-box-pack: center;
     -ms-flex-pack: center;
     -webkit-justify-content: center;
@@ -678,7 +678,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
   }
 }
 
-.emotion-358 {
+.emotion-356 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -695,16 +695,16 @@ exports[`Experience/ExchangeIcons renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-358 {
+  .emotion-356 {
     text-align: center;
   }
 }
 
-.emotion-360 {
+.emotion-358 {
   color: inherit;
 }
 
-.emotion-361 {
+.emotion-359 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -717,12 +717,12 @@ exports[`Experience/ExchangeIcons renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-361 {
+  .emotion-359 {
     grid-column: span 3;
   }
 }
 
-.emotion-362 {
+.emotion-360 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -738,21 +738,21 @@ exports[`Experience/ExchangeIcons renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-362 {
+  .emotion-360 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     justify-content: space-between;
   }
 }
 
-.emotion-363 {
+.emotion-361 {
   padding-left: 25px;
   padding-right: 25px;
   padding-start: 0;
 }
 
 @media (max-width: 576px) {
-  .emotion-363 {
+  .emotion-361 {
     margin-top: 35px;
     width: 50%;
     padding-left: 10px;
@@ -760,7 +760,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
   }
 }
 
-.emotion-364 {
+.emotion-362 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -775,18 +775,18 @@ exports[`Experience/ExchangeIcons renders 1`] = `
   margin-bottom: 20px;
 }
 
-.emotion-365 {
+.emotion-363 {
   margin-top: 8px;
   margin-bottom: 8px;
 }
 
-.emotion-405 {
+.emotion-403 {
   padding-left: 25px;
   padding-right: 25px;
 }
 
 @media (max-width: 576px) {
-  .emotion-405 {
+  .emotion-403 {
     margin-top: 35px;
     width: 50%;
     padding-left: 10px;
@@ -794,14 +794,14 @@ exports[`Experience/ExchangeIcons renders 1`] = `
   }
 }
 
-.emotion-479 {
+.emotion-477 {
   padding-left: 25px;
   padding-right: 25px;
   padding-end: 0;
 }
 
 @media (max-width: 576px) {
-  .emotion-479 {
+  .emotion-477 {
     margin-top: 35px;
     width: 50%;
     padding-left: 10px;
@@ -809,7 +809,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
   }
 }
 
-.emotion-548 {
+.emotion-546 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -838,7 +838,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-548 {
+  .emotion-546 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -855,7 +855,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-548 {
+  .emotion-546 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -867,39 +867,39 @@ exports[`Experience/ExchangeIcons renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-548 {
+  .emotion-546 {
     grid-template-columns: 1fr;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-548 {
+  .emotion-546 {
     grid-template-columns: 1fr;
   }
 }
 
 @media (min-width: 992px) {
-  .emotion-548 {
+  .emotion-546 {
     margin-top: 60px;
     margin-bottom: 60px;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-548 {
+  .emotion-546 {
     margin-top: 40px;
     margin-bottom: 40px;
   }
 }
 
 @media (max-width: 576px) {
-  .emotion-548 {
+  .emotion-546 {
     margin-top: 30px;
     margin-bottom: 30px;
   }
 }
 
-.emotion-549 {
+.emotion-547 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -917,7 +917,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-549 {
+  .emotion-547 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -932,7 +932,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
   }
 }
 
-.emotion-550 {
+.emotion-548 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -946,7 +946,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-550 {
+  .emotion-548 {
     -webkit-box-pack: center;
     -ms-flex-pack: center;
     -webkit-justify-content: center;
@@ -958,31 +958,31 @@ exports[`Experience/ExchangeIcons renders 1`] = `
   }
 }
 
-.emotion-551 {
+.emotion-549 {
   width: 20px;
   height: 20px;
   z-index: 10;
 }
 
 @media (max-width: 576px) {
-  .emotion-551 {
+  .emotion-549 {
     margin-bottom: 8px;
   }
 }
 
-.emotion-552 {
+.emotion-550 {
   margin-left: 10px;
   margin-right: 10px;
   z-index: 10;
 }
 
 @media (max-width: 576px) {
-  .emotion-552 {
+  .emotion-550 {
     display: none;
   }
 }
 
-.emotion-553 {
+.emotion-551 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -994,7 +994,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
   position: relative;
 }
 
-.emotion-554 {
+.emotion-552 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1021,7 +1021,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
   animation-name: animation-0;
 }
 
-.emotion-555 {
+.emotion-553 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -1044,12 +1044,12 @@ exports[`Experience/ExchangeIcons renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-555 {
+  .emotion-553 {
     text-align: center;
   }
 }
 
-.emotion-556 {
+.emotion-554 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1074,7 +1074,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
   animation-name: animation-2;
 }
 
-.emotion-557 {
+.emotion-555 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -2182,19 +2182,16 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 Key Imagery
               </a>
             </div>
-            <div
-              className="emotion-44"
-            />
           </div>
         </div>
       </div>
     </div>
   </div>
   <div
-    className="emotion-92"
+    className="emotion-91"
   >
     <div
-      className="emotion-93"
+      className="emotion-92"
     >
       <div
         className="emotion-37"
@@ -2847,26 +2844,23 @@ exports[`Experience/ExchangeIcons renders 1`] = `
             Key Imagery
           </a>
         </div>
-        <div
-          className="emotion-44"
-        />
       </div>
     </div>
     <div
-      className="emotion-149"
+      className="emotion-147"
     >
       <div
-        className="emotion-150"
+        className="emotion-148"
       >
         <div
-          className="emotion-151"
+          className="emotion-149"
           id="overview"
         >
           <div
-            className="emotion-152"
+            className="emotion-150"
           >
             <div
-              className="emotion-153"
+              className="emotion-151"
             >
               <div>
                 <h1
@@ -3033,7 +3027,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 }
               >
                 <a
-                  className="emotion-13 emotion-14 emotion-15 emotion-169"
+                  className="emotion-13 emotion-14 emotion-15 emotion-167"
                   href="/brand-policy"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -3054,10 +3048,10 @@ exports[`Experience/ExchangeIcons renders 1`] = `
               </div>
             </div>
             <div
-              className="emotion-170"
+              className="emotion-168"
             >
               <div
-                className="emotion-171"
+                className="emotion-169"
               >
                 <div>
                   <div
@@ -3072,7 +3066,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                     }
                   >
                     <div
-                      className="emotion-173"
+                      className="emotion-171"
                     >
                       <div
                         className="emotion-11"
@@ -3313,7 +3307,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                     }
                   >
                     <div
-                      className="emotion-173"
+                      className="emotion-171"
                     >
                       <div
                         className="emotion-11"
@@ -3555,7 +3549,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                     }
                   >
                     <div
-                      className="emotion-173"
+                      className="emotion-171"
                     >
                       <div
                         className="emotion-11"
@@ -3805,7 +3799,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                     }
                   >
                     <div
-                      className="emotion-173"
+                      className="emotion-171"
                     >
                       <div
                         className="emotion-11"
@@ -4046,7 +4040,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                     }
                   >
                     <div
-                      className="emotion-173"
+                      className="emotion-171"
                     >
                       <div
                         className="emotion-11"
@@ -4288,7 +4282,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                     }
                   >
                     <div
-                      className="emotion-173"
+                      className="emotion-171"
                     >
                       <div
                         className="emotion-11"
@@ -4538,7 +4532,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                     }
                   >
                     <div
-                      className="emotion-173"
+                      className="emotion-171"
                     >
                       <div
                         className="emotion-11"
@@ -4779,7 +4773,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                     }
                   >
                     <div
-                      className="emotion-173"
+                      className="emotion-171"
                     >
                       <div
                         className="emotion-11"
@@ -5021,7 +5015,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                     }
                   >
                     <div
-                      className="emotion-173"
+                      className="emotion-171"
                     >
                       <div
                         className="emotion-11"
@@ -5271,7 +5265,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                     }
                   >
                     <div
-                      className="emotion-173"
+                      className="emotion-171"
                     >
                       <div
                         className="emotion-11"
@@ -5512,7 +5506,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                     }
                   >
                     <div
-                      className="emotion-173"
+                      className="emotion-171"
                     >
                       <div
                         className="emotion-11"
@@ -5754,7 +5748,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                     }
                   >
                     <div
-                      className="emotion-173"
+                      className="emotion-171"
                     >
                       <div
                         className="emotion-11"
@@ -5991,20 +5985,20 @@ exports[`Experience/ExchangeIcons renders 1`] = `
     </div>
   </div>
   <div
-    className="emotion-352"
+    className="emotion-350"
     id="experience-footer"
   >
     <section
-      className="emotion-353"
+      className="emotion-351"
     >
       <div
-        className="emotion-354"
+        className="emotion-352"
       >
         <div
-          className="emotion-355"
+          className="emotion-353"
         >
           <div
-            className="emotion-356"
+            className="emotion-354"
           >
             <svg
               fill="none"
@@ -6027,19 +6021,19 @@ exports[`Experience/ExchangeIcons renders 1`] = `
             </svg>
           </div>
           <div
-            className="emotion-357"
+            className="emotion-355"
           >
             <p
-              className="emotion-358"
+              className="emotion-356"
             >
               Nothing herein constitutes an offer to sell, or the solicitation of an offer to buy, any securities or tokens.
             </p>
             <p
-              className="emotion-358"
+              className="emotion-356"
             >
               Read more in Celo 
               <a
-                className="emotion-360"
+                className="emotion-358"
                 href="/terms"
               >
                 Terms of Service
@@ -6048,21 +6042,21 @@ exports[`Experience/ExchangeIcons renders 1`] = `
           </div>
         </div>
         <div
-          className="emotion-361"
+          className="emotion-359"
         >
           <div
-            className="emotion-362"
+            className="emotion-360"
           >
             <div
-              className="emotion-363"
+              className="emotion-361"
             >
               <h6
-                className="emotion-364"
+                className="emotion-362"
               >
                 Celo
               </h6>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -6111,7 +6105,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -6160,7 +6154,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -6209,7 +6203,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -6258,7 +6252,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -6307,7 +6301,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -6356,7 +6350,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -6405,7 +6399,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -6455,15 +6449,15 @@ exports[`Experience/ExchangeIcons renders 1`] = `
               </div>
             </div>
             <div
-              className="emotion-405"
+              className="emotion-403"
             >
               <h6
-                className="emotion-364"
+                className="emotion-362"
               >
                 Technology
               </h6>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -6512,7 +6506,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -6561,7 +6555,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -6610,7 +6604,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -6659,7 +6653,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -6709,15 +6703,15 @@ exports[`Experience/ExchangeIcons renders 1`] = `
               </div>
             </div>
             <div
-              className="emotion-405"
+              className="emotion-403"
             >
               <h6
-                className="emotion-364"
+                className="emotion-362"
               >
                 Resources
               </h6>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -6766,7 +6760,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -6815,7 +6809,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -6864,7 +6858,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -6913,7 +6907,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -6962,7 +6956,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -7011,7 +7005,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -7060,7 +7054,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -7109,7 +7103,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -7159,15 +7153,15 @@ exports[`Experience/ExchangeIcons renders 1`] = `
               </div>
             </div>
             <div
-              className="emotion-479"
+              className="emotion-477"
             >
               <h6
-                className="emotion-364"
+                className="emotion-362"
               >
                 Social
               </h6>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -7240,7 +7234,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -7315,7 +7309,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -7388,7 +7382,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -7461,7 +7455,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -7536,7 +7530,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -7609,7 +7603,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -7681,7 +7675,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -7751,7 +7745,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -7821,7 +7815,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -7891,7 +7885,7 @@ exports[`Experience/ExchangeIcons renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-365"
+                className="emotion-363"
               >
                 <div
                   className="emotion-11"
@@ -7966,48 +7960,48 @@ exports[`Experience/ExchangeIcons renders 1`] = `
       </div>
     </section>
     <section
-      className="emotion-353"
+      className="emotion-351"
     >
       <div
-        className="emotion-548"
+        className="emotion-546"
       >
         <div
-          className="emotion-549"
+          className="emotion-547"
         >
           <div
-            className="emotion-550"
+            className="emotion-548"
           >
             <img
-              className="emotion-551"
+              className="emotion-549"
               height={100}
               src="/image.png"
               width={100}
             />
             <span
-              className="emotion-552"
+              className="emotion-550"
             >
               |
             </span>
             <div
-              className="emotion-553"
+              className="emotion-551"
             >
               <div
-                className="emotion-554"
+                className="emotion-552"
               />
               <span
-                className="emotion-555"
+                className="emotion-553"
               >
                 "
                 Change the Story
                 "
               </span>
               <div
-                className="emotion-556"
+                className="emotion-554"
               />
             </div>
           </div>
           <small
-            className="emotion-557"
+            className="emotion-555"
           >
             The Celo Foundation, © Celo 2021
           </small>

--- a/src/_page-tests/experience/__snapshots__/icons.test.tsx.snap
+++ b/src/_page-tests/experience/__snapshots__/icons.test.tsx.snap
@@ -331,7 +331,7 @@ exports[`Experience/Icons renders 1`] = `
   transition-duration: 500ms;
 }
 
-.emotion-92 {
+.emotion-91 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -353,7 +353,7 @@ exports[`Experience/Icons renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-92 {
+  .emotion-91 {
     z-index: -5;
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
@@ -363,18 +363,18 @@ exports[`Experience/Icons renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-92 {
+  .emotion-91 {
     max-width: 958px;
   }
 }
 
 @media (min-width: 992px) {
-  .emotion-92 {
+  .emotion-91 {
     max-width: 1080px;
   }
 }
 
-.emotion-93 {
+.emotion-92 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -393,12 +393,12 @@ exports[`Experience/Icons renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-93 {
+  .emotion-92 {
     display: none;
   }
 }
 
-.emotion-149 {
+.emotion-147 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -411,7 +411,7 @@ exports[`Experience/Icons renders 1`] = `
 }
 
 @media (min-width: 576px) {
-  .emotion-149 {
+  .emotion-147 {
     -webkit-flex: 1;
     -ms-flex: 1;
     flex: 1;
@@ -422,7 +422,7 @@ exports[`Experience/Icons renders 1`] = `
   }
 }
 
-.emotion-150 {
+.emotion-148 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -436,7 +436,7 @@ exports[`Experience/Icons renders 1`] = `
 }
 
 @media (min-width: 576px) {
-  .emotion-150 {
+  .emotion-148 {
     -webkit-transform: translateY(-25);
     -moz-transform: translateY(-25);
     -ms-transform: translateY(-25);
@@ -444,7 +444,7 @@ exports[`Experience/Icons renders 1`] = `
   }
 }
 
-.emotion-151 {
+.emotion-149 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -455,11 +455,11 @@ exports[`Experience/Icons renders 1`] = `
   flex-direction: column;
 }
 
-.emotion-165 {
+.emotion-163 {
   min-height: 100vh;
 }
 
-.emotion-169 {
+.emotion-167 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -479,7 +479,7 @@ exports[`Experience/Icons renders 1`] = `
   transition-property: opacity;
 }
 
-.emotion-170 {
+.emotion-168 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -493,21 +493,21 @@ exports[`Experience/Icons renders 1`] = `
   flex-wrap: wrap;
 }
 
-.emotion-171 {
+.emotion-169 {
   width: 260px;
 }
 
-.emotion-173 {
+.emotion-171 {
   opacity: 0;
 }
 
-.emotion-203 {
+.emotion-201 {
   z-index: -10;
   background-color: #FFFFFF;
   margin-top: 50px;
 }
 
-.emotion-204 {
+.emotion-202 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -527,7 +527,7 @@ exports[`Experience/Icons renders 1`] = `
   width: 100%;
 }
 
-.emotion-205 {
+.emotion-203 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -556,7 +556,7 @@ exports[`Experience/Icons renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-205 {
+  .emotion-203 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -573,7 +573,7 @@ exports[`Experience/Icons renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-205 {
+  .emotion-203 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -585,36 +585,36 @@ exports[`Experience/Icons renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-205 {
+  .emotion-203 {
     grid-template-columns: 1fr 1fr 1fr;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-205 {
+  .emotion-203 {
     grid-template-columns: 1fr 1fr 1fr;
   }
 }
 
 @media (min-width: 992px) {
-  .emotion-205 {
+  .emotion-203 {
     margin-top: 60px;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-205 {
+  .emotion-203 {
     margin-top: 40px;
   }
 }
 
 @media (max-width: 576px) {
-  .emotion-205 {
+  .emotion-203 {
     margin-top: 30px;
   }
 }
 
-.emotion-206 {
+.emotion-204 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -627,12 +627,12 @@ exports[`Experience/Icons renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-206 {
+  .emotion-204 {
     grid-column: span 3;
   }
 }
 
-.emotion-207 {
+.emotion-205 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -645,7 +645,7 @@ exports[`Experience/Icons renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-207 {
+  .emotion-205 {
     margin-bottom: 30px;
     -webkit-box-pack: center;
     -ms-flex-pack: center;
@@ -658,7 +658,7 @@ exports[`Experience/Icons renders 1`] = `
   }
 }
 
-.emotion-208 {
+.emotion-206 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -671,7 +671,7 @@ exports[`Experience/Icons renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-208 {
+  .emotion-206 {
     -webkit-box-pack: center;
     -ms-flex-pack: center;
     -webkit-justify-content: center;
@@ -683,7 +683,7 @@ exports[`Experience/Icons renders 1`] = `
   }
 }
 
-.emotion-209 {
+.emotion-207 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -700,16 +700,16 @@ exports[`Experience/Icons renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-209 {
+  .emotion-207 {
     text-align: center;
   }
 }
 
-.emotion-211 {
+.emotion-209 {
   color: inherit;
 }
 
-.emotion-212 {
+.emotion-210 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -722,12 +722,12 @@ exports[`Experience/Icons renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-212 {
+  .emotion-210 {
     grid-column: span 3;
   }
 }
 
-.emotion-213 {
+.emotion-211 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -743,21 +743,21 @@ exports[`Experience/Icons renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-213 {
+  .emotion-211 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     justify-content: space-between;
   }
 }
 
-.emotion-214 {
+.emotion-212 {
   padding-left: 25px;
   padding-right: 25px;
   padding-start: 0;
 }
 
 @media (max-width: 576px) {
-  .emotion-214 {
+  .emotion-212 {
     margin-top: 35px;
     width: 50%;
     padding-left: 10px;
@@ -765,7 +765,7 @@ exports[`Experience/Icons renders 1`] = `
   }
 }
 
-.emotion-215 {
+.emotion-213 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -780,18 +780,18 @@ exports[`Experience/Icons renders 1`] = `
   margin-bottom: 20px;
 }
 
-.emotion-216 {
+.emotion-214 {
   margin-top: 8px;
   margin-bottom: 8px;
 }
 
-.emotion-256 {
+.emotion-254 {
   padding-left: 25px;
   padding-right: 25px;
 }
 
 @media (max-width: 576px) {
-  .emotion-256 {
+  .emotion-254 {
     margin-top: 35px;
     width: 50%;
     padding-left: 10px;
@@ -799,14 +799,14 @@ exports[`Experience/Icons renders 1`] = `
   }
 }
 
-.emotion-330 {
+.emotion-328 {
   padding-left: 25px;
   padding-right: 25px;
   padding-end: 0;
 }
 
 @media (max-width: 576px) {
-  .emotion-330 {
+  .emotion-328 {
     margin-top: 35px;
     width: 50%;
     padding-left: 10px;
@@ -814,7 +814,7 @@ exports[`Experience/Icons renders 1`] = `
   }
 }
 
-.emotion-399 {
+.emotion-397 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -843,7 +843,7 @@ exports[`Experience/Icons renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-399 {
+  .emotion-397 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -860,7 +860,7 @@ exports[`Experience/Icons renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-399 {
+  .emotion-397 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -872,39 +872,39 @@ exports[`Experience/Icons renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-399 {
+  .emotion-397 {
     grid-template-columns: 1fr;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-399 {
+  .emotion-397 {
     grid-template-columns: 1fr;
   }
 }
 
 @media (min-width: 992px) {
-  .emotion-399 {
+  .emotion-397 {
     margin-top: 60px;
     margin-bottom: 60px;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-399 {
+  .emotion-397 {
     margin-top: 40px;
     margin-bottom: 40px;
   }
 }
 
 @media (max-width: 576px) {
-  .emotion-399 {
+  .emotion-397 {
     margin-top: 30px;
     margin-bottom: 30px;
   }
 }
 
-.emotion-400 {
+.emotion-398 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -922,7 +922,7 @@ exports[`Experience/Icons renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-400 {
+  .emotion-398 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -937,7 +937,7 @@ exports[`Experience/Icons renders 1`] = `
   }
 }
 
-.emotion-401 {
+.emotion-399 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -951,7 +951,7 @@ exports[`Experience/Icons renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-401 {
+  .emotion-399 {
     -webkit-box-pack: center;
     -ms-flex-pack: center;
     -webkit-justify-content: center;
@@ -963,31 +963,31 @@ exports[`Experience/Icons renders 1`] = `
   }
 }
 
-.emotion-402 {
+.emotion-400 {
   width: 20px;
   height: 20px;
   z-index: 10;
 }
 
 @media (max-width: 576px) {
-  .emotion-402 {
+  .emotion-400 {
     margin-bottom: 8px;
   }
 }
 
-.emotion-403 {
+.emotion-401 {
   margin-left: 10px;
   margin-right: 10px;
   z-index: 10;
 }
 
 @media (max-width: 576px) {
-  .emotion-403 {
+  .emotion-401 {
     display: none;
   }
 }
 
-.emotion-404 {
+.emotion-402 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -999,7 +999,7 @@ exports[`Experience/Icons renders 1`] = `
   position: relative;
 }
 
-.emotion-405 {
+.emotion-403 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1026,7 +1026,7 @@ exports[`Experience/Icons renders 1`] = `
   animation-name: animation-0;
 }
 
-.emotion-406 {
+.emotion-404 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -1049,12 +1049,12 @@ exports[`Experience/Icons renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-406 {
+  .emotion-404 {
     text-align: center;
   }
 }
 
-.emotion-407 {
+.emotion-405 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1079,7 +1079,7 @@ exports[`Experience/Icons renders 1`] = `
   animation-name: animation-2;
 }
 
-.emotion-408 {
+.emotion-406 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -2187,19 +2187,16 @@ exports[`Experience/Icons renders 1`] = `
                 Key Imagery
               </a>
             </div>
-            <div
-              className="emotion-44"
-            />
           </div>
         </div>
       </div>
     </div>
   </div>
   <div
-    className="emotion-92"
+    className="emotion-91"
   >
     <div
-      className="emotion-93"
+      className="emotion-92"
     >
       <div
         className="emotion-37"
@@ -2852,19 +2849,16 @@ exports[`Experience/Icons renders 1`] = `
             Key Imagery
           </a>
         </div>
-        <div
-          className="emotion-44"
-        />
       </div>
     </div>
     <div
-      className="emotion-149"
+      className="emotion-147"
     >
       <div
-        className="emotion-150"
+        className="emotion-148"
       >
         <div
-          className="emotion-151"
+          className="emotion-149"
           id="overview"
         >
           <div
@@ -2976,7 +2970,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 }
               >
                 <a
-                  className="emotion-13 emotion-14 emotion-15 emotion-164"
+                  className="emotion-13 emotion-14 emotion-15 emotion-162"
                   href="/brand-policy"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -2998,7 +2992,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
               . You may not remix or transform the icons.
             </div>
             <div
-              className="emotion-165"
+              className="emotion-163"
             >
               <div
                 className="emotion-11"
@@ -3033,7 +3027,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                   autoCapitalize="sentences"
                   autoComplete="on"
                   autoCorrect="on"
-                  className="emotion-168"
+                  className="emotion-166"
                   dir="auto"
                   onBlur={[Function]}
                   onChange={[Function]}
@@ -3084,15 +3078,15 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
               </div>
               <span
                 aria-hidden={true}
-                className="emotion-169"
+                className="emotion-167"
               >
                 2 Matching Icons
               </span>
               <div
-                className="emotion-170"
+                className="emotion-168"
               >
                 <div
-                  className="emotion-171"
+                  className="emotion-169"
                   data-testid="1"
                 >
                   <div
@@ -3107,7 +3101,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                     }
                   >
                     <div
-                      className="emotion-173"
+                      className="emotion-171"
                     >
                       <div
                         className="emotion-11"
@@ -3331,7 +3325,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                   </div>
                 </div>
                 <div
-                  className="emotion-171"
+                  className="emotion-169"
                   data-testid="2"
                 >
                   <div
@@ -3346,7 +3340,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                     }
                   >
                     <div
-                      className="emotion-173"
+                      className="emotion-171"
                     >
                       <div
                         className="emotion-11"
@@ -3577,20 +3571,20 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
     </div>
   </div>
   <div
-    className="emotion-203"
+    className="emotion-201"
     id="experience-footer"
   >
     <section
-      className="emotion-204"
+      className="emotion-202"
     >
       <div
-        className="emotion-205"
+        className="emotion-203"
       >
         <div
-          className="emotion-206"
+          className="emotion-204"
         >
           <div
-            className="emotion-207"
+            className="emotion-205"
           >
             <svg
               fill="none"
@@ -3613,19 +3607,19 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
             </svg>
           </div>
           <div
-            className="emotion-208"
+            className="emotion-206"
           >
             <p
-              className="emotion-209"
+              className="emotion-207"
             >
               Nothing herein constitutes an offer to sell, or the solicitation of an offer to buy, any securities or tokens.
             </p>
             <p
-              className="emotion-209"
+              className="emotion-207"
             >
               Read more in Celo 
               <a
-                className="emotion-211"
+                className="emotion-209"
                 href="/terms"
               >
                 Terms of Service
@@ -3634,21 +3628,21 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
           </div>
         </div>
         <div
-          className="emotion-212"
+          className="emotion-210"
         >
           <div
-            className="emotion-213"
+            className="emotion-211"
           >
             <div
-              className="emotion-214"
+              className="emotion-212"
             >
               <h6
-                className="emotion-215"
+                className="emotion-213"
               >
                 Celo
               </h6>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -3697,7 +3691,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -3746,7 +3740,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -3795,7 +3789,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -3844,7 +3838,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -3893,7 +3887,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -3942,7 +3936,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -3991,7 +3985,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -4041,15 +4035,15 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
               </div>
             </div>
             <div
-              className="emotion-256"
+              className="emotion-254"
             >
               <h6
-                className="emotion-215"
+                className="emotion-213"
               >
                 Technology
               </h6>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -4098,7 +4092,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -4147,7 +4141,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -4196,7 +4190,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -4245,7 +4239,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -4295,15 +4289,15 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
               </div>
             </div>
             <div
-              className="emotion-256"
+              className="emotion-254"
             >
               <h6
-                className="emotion-215"
+                className="emotion-213"
               >
                 Resources
               </h6>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -4352,7 +4346,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -4401,7 +4395,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -4450,7 +4444,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -4499,7 +4493,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -4548,7 +4542,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -4597,7 +4591,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -4646,7 +4640,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -4695,7 +4689,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -4745,15 +4739,15 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
               </div>
             </div>
             <div
-              className="emotion-330"
+              className="emotion-328"
             >
               <h6
-                className="emotion-215"
+                className="emotion-213"
               >
                 Social
               </h6>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -4826,7 +4820,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -4901,7 +4895,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -4974,7 +4968,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -5047,7 +5041,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -5122,7 +5116,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -5195,7 +5189,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -5267,7 +5261,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -5337,7 +5331,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -5407,7 +5401,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -5477,7 +5471,7 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
                 </div>
               </div>
               <div
-                className="emotion-216"
+                className="emotion-214"
               >
                 <div
                   className="emotion-11"
@@ -5552,48 +5546,48 @@ Celo icons have descriptions that act as guidelines. While some descriptions are
       </div>
     </section>
     <section
-      className="emotion-204"
+      className="emotion-202"
     >
       <div
-        className="emotion-399"
+        className="emotion-397"
       >
         <div
-          className="emotion-400"
+          className="emotion-398"
         >
           <div
-            className="emotion-401"
+            className="emotion-399"
           >
             <img
-              className="emotion-402"
+              className="emotion-400"
               height={100}
               src="/image.png"
               width={100}
             />
             <span
-              className="emotion-403"
+              className="emotion-401"
             >
               |
             </span>
             <div
-              className="emotion-404"
+              className="emotion-402"
             >
               <div
-                className="emotion-405"
+                className="emotion-403"
               />
               <span
-                className="emotion-406"
+                className="emotion-404"
               >
                 "
                 Change the Story
                 "
               </span>
               <div
-                className="emotion-407"
+                className="emotion-405"
               />
             </div>
           </div>
           <small
-            className="emotion-408"
+            className="emotion-406"
           >
             The Celo Foundation, © Celo 2021
           </small>

--- a/src/_page-tests/experience/__snapshots__/index.test.tsx.snap
+++ b/src/_page-tests/experience/__snapshots__/index.test.tsx.snap
@@ -331,7 +331,7 @@ exports[`Experience/Brandkit renders 1`] = `
   transition-duration: 500ms;
 }
 
-.emotion-92 {
+.emotion-91 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -353,7 +353,7 @@ exports[`Experience/Brandkit renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-92 {
+  .emotion-91 {
     z-index: -5;
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
@@ -363,18 +363,18 @@ exports[`Experience/Brandkit renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-92 {
+  .emotion-91 {
     max-width: 958px;
   }
 }
 
 @media (min-width: 992px) {
-  .emotion-92 {
+  .emotion-91 {
     max-width: 1080px;
   }
 }
 
-.emotion-93 {
+.emotion-92 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -393,12 +393,12 @@ exports[`Experience/Brandkit renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-93 {
+  .emotion-92 {
     display: none;
   }
 }
 
-.emotion-149 {
+.emotion-147 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -411,7 +411,7 @@ exports[`Experience/Brandkit renders 1`] = `
 }
 
 @media (min-width: 576px) {
-  .emotion-149 {
+  .emotion-147 {
     -webkit-flex: 1;
     -ms-flex: 1;
     flex: 1;
@@ -422,7 +422,7 @@ exports[`Experience/Brandkit renders 1`] = `
   }
 }
 
-.emotion-150 {
+.emotion-148 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -436,7 +436,7 @@ exports[`Experience/Brandkit renders 1`] = `
 }
 
 @media (min-width: 576px) {
-  .emotion-150 {
+  .emotion-148 {
     -webkit-transform: translateY(-25);
     -moz-transform: translateY(-25);
     -ms-transform: translateY(-25);
@@ -444,7 +444,7 @@ exports[`Experience/Brandkit renders 1`] = `
   }
 }
 
-.emotion-151 {
+.emotion-149 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -455,13 +455,13 @@ exports[`Experience/Brandkit renders 1`] = `
   flex-direction: column;
 }
 
-.emotion-179 {
+.emotion-177 {
   z-index: -10;
   background-color: #FFFFFF;
   margin-top: 50px;
 }
 
-.emotion-180 {
+.emotion-178 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -481,7 +481,7 @@ exports[`Experience/Brandkit renders 1`] = `
   width: 100%;
 }
 
-.emotion-181 {
+.emotion-179 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -510,7 +510,7 @@ exports[`Experience/Brandkit renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-181 {
+  .emotion-179 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -527,7 +527,7 @@ exports[`Experience/Brandkit renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-181 {
+  .emotion-179 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -539,36 +539,36 @@ exports[`Experience/Brandkit renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-181 {
+  .emotion-179 {
     grid-template-columns: 1fr 1fr 1fr;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-181 {
+  .emotion-179 {
     grid-template-columns: 1fr 1fr 1fr;
   }
 }
 
 @media (min-width: 992px) {
-  .emotion-181 {
+  .emotion-179 {
     margin-top: 60px;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-181 {
+  .emotion-179 {
     margin-top: 40px;
   }
 }
 
 @media (max-width: 576px) {
-  .emotion-181 {
+  .emotion-179 {
     margin-top: 30px;
   }
 }
 
-.emotion-182 {
+.emotion-180 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -581,12 +581,12 @@ exports[`Experience/Brandkit renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-182 {
+  .emotion-180 {
     grid-column: span 3;
   }
 }
 
-.emotion-183 {
+.emotion-181 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -599,7 +599,7 @@ exports[`Experience/Brandkit renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-183 {
+  .emotion-181 {
     margin-bottom: 30px;
     -webkit-box-pack: center;
     -ms-flex-pack: center;
@@ -612,7 +612,7 @@ exports[`Experience/Brandkit renders 1`] = `
   }
 }
 
-.emotion-184 {
+.emotion-182 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -625,7 +625,7 @@ exports[`Experience/Brandkit renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-184 {
+  .emotion-182 {
     -webkit-box-pack: center;
     -ms-flex-pack: center;
     -webkit-justify-content: center;
@@ -637,7 +637,7 @@ exports[`Experience/Brandkit renders 1`] = `
   }
 }
 
-.emotion-185 {
+.emotion-183 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -654,16 +654,16 @@ exports[`Experience/Brandkit renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-185 {
+  .emotion-183 {
     text-align: center;
   }
 }
 
-.emotion-187 {
+.emotion-185 {
   color: inherit;
 }
 
-.emotion-188 {
+.emotion-186 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -676,12 +676,12 @@ exports[`Experience/Brandkit renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-188 {
+  .emotion-186 {
     grid-column: span 3;
   }
 }
 
-.emotion-189 {
+.emotion-187 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -697,21 +697,21 @@ exports[`Experience/Brandkit renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-189 {
+  .emotion-187 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     justify-content: space-between;
   }
 }
 
-.emotion-190 {
+.emotion-188 {
   padding-left: 25px;
   padding-right: 25px;
   padding-start: 0;
 }
 
 @media (max-width: 576px) {
-  .emotion-190 {
+  .emotion-188 {
     margin-top: 35px;
     width: 50%;
     padding-left: 10px;
@@ -719,7 +719,7 @@ exports[`Experience/Brandkit renders 1`] = `
   }
 }
 
-.emotion-191 {
+.emotion-189 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -734,18 +734,18 @@ exports[`Experience/Brandkit renders 1`] = `
   margin-bottom: 20px;
 }
 
-.emotion-192 {
+.emotion-190 {
   margin-top: 8px;
   margin-bottom: 8px;
 }
 
-.emotion-232 {
+.emotion-230 {
   padding-left: 25px;
   padding-right: 25px;
 }
 
 @media (max-width: 576px) {
-  .emotion-232 {
+  .emotion-230 {
     margin-top: 35px;
     width: 50%;
     padding-left: 10px;
@@ -753,14 +753,14 @@ exports[`Experience/Brandkit renders 1`] = `
   }
 }
 
-.emotion-306 {
+.emotion-304 {
   padding-left: 25px;
   padding-right: 25px;
   padding-end: 0;
 }
 
 @media (max-width: 576px) {
-  .emotion-306 {
+  .emotion-304 {
     margin-top: 35px;
     width: 50%;
     padding-left: 10px;
@@ -768,7 +768,7 @@ exports[`Experience/Brandkit renders 1`] = `
   }
 }
 
-.emotion-375 {
+.emotion-373 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -797,7 +797,7 @@ exports[`Experience/Brandkit renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-375 {
+  .emotion-373 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -814,7 +814,7 @@ exports[`Experience/Brandkit renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-375 {
+  .emotion-373 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -826,39 +826,39 @@ exports[`Experience/Brandkit renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-375 {
+  .emotion-373 {
     grid-template-columns: 1fr;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-375 {
+  .emotion-373 {
     grid-template-columns: 1fr;
   }
 }
 
 @media (min-width: 992px) {
-  .emotion-375 {
+  .emotion-373 {
     margin-top: 60px;
     margin-bottom: 60px;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-375 {
+  .emotion-373 {
     margin-top: 40px;
     margin-bottom: 40px;
   }
 }
 
 @media (max-width: 576px) {
-  .emotion-375 {
+  .emotion-373 {
     margin-top: 30px;
     margin-bottom: 30px;
   }
 }
 
-.emotion-376 {
+.emotion-374 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -876,7 +876,7 @@ exports[`Experience/Brandkit renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-376 {
+  .emotion-374 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -891,7 +891,7 @@ exports[`Experience/Brandkit renders 1`] = `
   }
 }
 
-.emotion-377 {
+.emotion-375 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -905,7 +905,7 @@ exports[`Experience/Brandkit renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-377 {
+  .emotion-375 {
     -webkit-box-pack: center;
     -ms-flex-pack: center;
     -webkit-justify-content: center;
@@ -917,31 +917,31 @@ exports[`Experience/Brandkit renders 1`] = `
   }
 }
 
-.emotion-378 {
+.emotion-376 {
   width: 20px;
   height: 20px;
   z-index: 10;
 }
 
 @media (max-width: 576px) {
-  .emotion-378 {
+  .emotion-376 {
     margin-bottom: 8px;
   }
 }
 
-.emotion-379 {
+.emotion-377 {
   margin-left: 10px;
   margin-right: 10px;
   z-index: 10;
 }
 
 @media (max-width: 576px) {
-  .emotion-379 {
+  .emotion-377 {
     display: none;
   }
 }
 
-.emotion-380 {
+.emotion-378 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -953,7 +953,7 @@ exports[`Experience/Brandkit renders 1`] = `
   position: relative;
 }
 
-.emotion-381 {
+.emotion-379 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -980,7 +980,7 @@ exports[`Experience/Brandkit renders 1`] = `
   animation-name: animation-0;
 }
 
-.emotion-382 {
+.emotion-380 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -1003,12 +1003,12 @@ exports[`Experience/Brandkit renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-382 {
+  .emotion-380 {
     text-align: center;
   }
 }
 
-.emotion-383 {
+.emotion-381 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1033,7 +1033,7 @@ exports[`Experience/Brandkit renders 1`] = `
   animation-name: animation-2;
 }
 
-.emotion-384 {
+.emotion-382 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -2141,19 +2141,16 @@ exports[`Experience/Brandkit renders 1`] = `
                 Key Imagery
               </a>
             </div>
-            <div
-              className="emotion-44"
-            />
           </div>
         </div>
       </div>
     </div>
   </div>
   <div
-    className="emotion-92"
+    className="emotion-91"
   >
     <div
-      className="emotion-93"
+      className="emotion-92"
     >
       <div
         className="emotion-37"
@@ -2806,19 +2803,16 @@ exports[`Experience/Brandkit renders 1`] = `
             Key Imagery
           </a>
         </div>
-        <div
-          className="emotion-44"
-        />
       </div>
     </div>
     <div
-      className="emotion-149"
+      className="emotion-147"
     >
       <div
-        className="emotion-150"
+        className="emotion-148"
       >
         <div
-          className="emotion-151"
+          className="emotion-149"
           id="overview"
         >
           <div
@@ -2930,7 +2924,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 }
               >
                 <li
-                  className="emotion-13 emotion-15 emotion-164"
+                  className="emotion-13 emotion-15 emotion-162"
                   role="listitem"
                   style={
                     Object {
@@ -2948,7 +2942,7 @@ exports[`Experience/Brandkit renders 1`] = `
                   Register the trademark, domain, Celo Brand Asset, or derivative
                 </li>
                 <li
-                  className="emotion-13 emotion-15 emotion-164"
+                  className="emotion-13 emotion-15 emotion-162"
                   role="listitem"
                   style={
                     Object {
@@ -2970,7 +2964,7 @@ exports[`Experience/Brandkit renders 1`] = `
           </div>
         </div>
         <div
-          className="emotion-151"
+          className="emotion-149"
           id="brand-voice"
         >
           <div
@@ -3039,7 +3033,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 }
               >
                 <a
-                  className="emotion-13 emotion-14 emotion-15 emotion-164"
+                  className="emotion-13 emotion-14 emotion-15 emotion-162"
                   href="https://docs.google.com/document/d/1Y1mfpBGad_8ZxSuIqwX52MWGEMfoWGt5HXc7sZp9h70/edit?usp=sharing"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -3067,20 +3061,20 @@ exports[`Experience/Brandkit renders 1`] = `
     </div>
   </div>
   <div
-    className="emotion-179"
+    className="emotion-177"
     id="experience-footer"
   >
     <section
-      className="emotion-180"
+      className="emotion-178"
     >
       <div
-        className="emotion-181"
+        className="emotion-179"
       >
         <div
-          className="emotion-182"
+          className="emotion-180"
         >
           <div
-            className="emotion-183"
+            className="emotion-181"
           >
             <svg
               fill="none"
@@ -3103,19 +3097,19 @@ exports[`Experience/Brandkit renders 1`] = `
             </svg>
           </div>
           <div
-            className="emotion-184"
+            className="emotion-182"
           >
             <p
-              className="emotion-185"
+              className="emotion-183"
             >
               Nothing herein constitutes an offer to sell, or the solicitation of an offer to buy, any securities or tokens.
             </p>
             <p
-              className="emotion-185"
+              className="emotion-183"
             >
               Read more in Celo 
               <a
-                className="emotion-187"
+                className="emotion-185"
                 href="/terms"
               >
                 Terms of Service
@@ -3124,21 +3118,21 @@ exports[`Experience/Brandkit renders 1`] = `
           </div>
         </div>
         <div
-          className="emotion-188"
+          className="emotion-186"
         >
           <div
-            className="emotion-189"
+            className="emotion-187"
           >
             <div
-              className="emotion-190"
+              className="emotion-188"
             >
               <h6
-                className="emotion-191"
+                className="emotion-189"
               >
                 Celo
               </h6>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -3187,7 +3181,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -3236,7 +3230,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -3285,7 +3279,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -3334,7 +3328,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -3383,7 +3377,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -3432,7 +3426,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -3481,7 +3475,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -3531,15 +3525,15 @@ exports[`Experience/Brandkit renders 1`] = `
               </div>
             </div>
             <div
-              className="emotion-232"
+              className="emotion-230"
             >
               <h6
-                className="emotion-191"
+                className="emotion-189"
               >
                 Technology
               </h6>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -3588,7 +3582,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -3637,7 +3631,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -3686,7 +3680,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -3735,7 +3729,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -3785,15 +3779,15 @@ exports[`Experience/Brandkit renders 1`] = `
               </div>
             </div>
             <div
-              className="emotion-232"
+              className="emotion-230"
             >
               <h6
-                className="emotion-191"
+                className="emotion-189"
               >
                 Resources
               </h6>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -3842,7 +3836,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -3891,7 +3885,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -3940,7 +3934,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -3989,7 +3983,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -4038,7 +4032,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -4087,7 +4081,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -4136,7 +4130,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -4185,7 +4179,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -4235,15 +4229,15 @@ exports[`Experience/Brandkit renders 1`] = `
               </div>
             </div>
             <div
-              className="emotion-306"
+              className="emotion-304"
             >
               <h6
-                className="emotion-191"
+                className="emotion-189"
               >
                 Social
               </h6>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -4316,7 +4310,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -4391,7 +4385,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -4464,7 +4458,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -4537,7 +4531,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -4612,7 +4606,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -4685,7 +4679,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -4757,7 +4751,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -4827,7 +4821,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -4897,7 +4891,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -4967,7 +4961,7 @@ exports[`Experience/Brandkit renders 1`] = `
                 </div>
               </div>
               <div
-                className="emotion-192"
+                className="emotion-190"
               >
                 <div
                   className="emotion-11"
@@ -5042,48 +5036,48 @@ exports[`Experience/Brandkit renders 1`] = `
       </div>
     </section>
     <section
-      className="emotion-180"
+      className="emotion-178"
     >
       <div
-        className="emotion-375"
+        className="emotion-373"
       >
         <div
-          className="emotion-376"
+          className="emotion-374"
         >
           <div
-            className="emotion-377"
+            className="emotion-375"
           >
             <img
-              className="emotion-378"
+              className="emotion-376"
               height={100}
               src="/image.png"
               width={100}
             />
             <span
-              className="emotion-379"
+              className="emotion-377"
             >
               |
             </span>
             <div
-              className="emotion-380"
+              className="emotion-378"
             >
               <div
-                className="emotion-381"
+                className="emotion-379"
               />
               <span
-                className="emotion-382"
+                className="emotion-380"
               >
                 "
                 Change the Story
                 "
               </span>
               <div
-                className="emotion-383"
+                className="emotion-381"
               />
             </div>
           </div>
           <small
-            className="emotion-384"
+            className="emotion-382"
           >
             The Celo Foundation, © Celo 2021
           </small>

--- a/src/_page-tests/experience/__snapshots__/key-imagery.test.tsx.snap
+++ b/src/_page-tests/experience/__snapshots__/key-imagery.test.tsx.snap
@@ -331,7 +331,7 @@ exports[`Experience/KeyImagery renders 1`] = `
   transition-duration: 500ms;
 }
 
-.emotion-92 {
+.emotion-91 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -353,7 +353,7 @@ exports[`Experience/KeyImagery renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-92 {
+  .emotion-91 {
     z-index: -5;
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
@@ -363,18 +363,18 @@ exports[`Experience/KeyImagery renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-92 {
+  .emotion-91 {
     max-width: 958px;
   }
 }
 
 @media (min-width: 992px) {
-  .emotion-92 {
+  .emotion-91 {
     max-width: 1080px;
   }
 }
 
-.emotion-93 {
+.emotion-92 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -393,12 +393,12 @@ exports[`Experience/KeyImagery renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-93 {
+  .emotion-92 {
     display: none;
   }
 }
 
-.emotion-149 {
+.emotion-147 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -411,7 +411,7 @@ exports[`Experience/KeyImagery renders 1`] = `
 }
 
 @media (min-width: 576px) {
-  .emotion-149 {
+  .emotion-147 {
     -webkit-flex: 1;
     -ms-flex: 1;
     flex: 1;
@@ -422,7 +422,7 @@ exports[`Experience/KeyImagery renders 1`] = `
   }
 }
 
-.emotion-150 {
+.emotion-148 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -436,7 +436,7 @@ exports[`Experience/KeyImagery renders 1`] = `
 }
 
 @media (min-width: 576px) {
-  .emotion-150 {
+  .emotion-148 {
     -webkit-transform: translateY(-25);
     -moz-transform: translateY(-25);
     -ms-transform: translateY(-25);
@@ -444,7 +444,7 @@ exports[`Experience/KeyImagery renders 1`] = `
   }
 }
 
-.emotion-151 {
+.emotion-149 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -455,17 +455,17 @@ exports[`Experience/KeyImagery renders 1`] = `
   flex-direction: column;
 }
 
-.emotion-172 {
+.emotion-169 {
   opacity: 0;
 }
 
-.emotion-207 {
+.emotion-183 {
   z-index: -10;
   background-color: #FFFFFF;
   margin-top: 50px;
 }
 
-.emotion-208 {
+.emotion-184 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -485,7 +485,7 @@ exports[`Experience/KeyImagery renders 1`] = `
   width: 100%;
 }
 
-.emotion-209 {
+.emotion-185 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -514,7 +514,7 @@ exports[`Experience/KeyImagery renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-209 {
+  .emotion-185 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -531,7 +531,7 @@ exports[`Experience/KeyImagery renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-209 {
+  .emotion-185 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -543,36 +543,36 @@ exports[`Experience/KeyImagery renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-209 {
+  .emotion-185 {
     grid-template-columns: 1fr 1fr 1fr;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-209 {
+  .emotion-185 {
     grid-template-columns: 1fr 1fr 1fr;
   }
 }
 
 @media (min-width: 992px) {
-  .emotion-209 {
+  .emotion-185 {
     margin-top: 60px;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-209 {
+  .emotion-185 {
     margin-top: 40px;
   }
 }
 
 @media (max-width: 576px) {
-  .emotion-209 {
+  .emotion-185 {
     margin-top: 30px;
   }
 }
 
-.emotion-210 {
+.emotion-186 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -585,12 +585,12 @@ exports[`Experience/KeyImagery renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-210 {
+  .emotion-186 {
     grid-column: span 3;
   }
 }
 
-.emotion-211 {
+.emotion-187 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -603,7 +603,7 @@ exports[`Experience/KeyImagery renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-211 {
+  .emotion-187 {
     margin-bottom: 30px;
     -webkit-box-pack: center;
     -ms-flex-pack: center;
@@ -616,7 +616,7 @@ exports[`Experience/KeyImagery renders 1`] = `
   }
 }
 
-.emotion-212 {
+.emotion-188 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -629,7 +629,7 @@ exports[`Experience/KeyImagery renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-212 {
+  .emotion-188 {
     -webkit-box-pack: center;
     -ms-flex-pack: center;
     -webkit-justify-content: center;
@@ -641,7 +641,7 @@ exports[`Experience/KeyImagery renders 1`] = `
   }
 }
 
-.emotion-213 {
+.emotion-189 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -658,16 +658,16 @@ exports[`Experience/KeyImagery renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-213 {
+  .emotion-189 {
     text-align: center;
   }
 }
 
-.emotion-215 {
+.emotion-191 {
   color: inherit;
 }
 
-.emotion-216 {
+.emotion-192 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -680,12 +680,12 @@ exports[`Experience/KeyImagery renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-216 {
+  .emotion-192 {
     grid-column: span 3;
   }
 }
 
-.emotion-217 {
+.emotion-193 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -701,21 +701,21 @@ exports[`Experience/KeyImagery renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-217 {
+  .emotion-193 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     justify-content: space-between;
   }
 }
 
-.emotion-218 {
+.emotion-194 {
   padding-left: 25px;
   padding-right: 25px;
   padding-start: 0;
 }
 
 @media (max-width: 576px) {
-  .emotion-218 {
+  .emotion-194 {
     margin-top: 35px;
     width: 50%;
     padding-left: 10px;
@@ -723,7 +723,7 @@ exports[`Experience/KeyImagery renders 1`] = `
   }
 }
 
-.emotion-219 {
+.emotion-195 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -738,18 +738,18 @@ exports[`Experience/KeyImagery renders 1`] = `
   margin-bottom: 20px;
 }
 
-.emotion-220 {
+.emotion-196 {
   margin-top: 8px;
   margin-bottom: 8px;
 }
 
-.emotion-260 {
+.emotion-236 {
   padding-left: 25px;
   padding-right: 25px;
 }
 
 @media (max-width: 576px) {
-  .emotion-260 {
+  .emotion-236 {
     margin-top: 35px;
     width: 50%;
     padding-left: 10px;
@@ -757,14 +757,14 @@ exports[`Experience/KeyImagery renders 1`] = `
   }
 }
 
-.emotion-334 {
+.emotion-310 {
   padding-left: 25px;
   padding-right: 25px;
   padding-end: 0;
 }
 
 @media (max-width: 576px) {
-  .emotion-334 {
+  .emotion-310 {
     margin-top: 35px;
     width: 50%;
     padding-left: 10px;
@@ -772,7 +772,7 @@ exports[`Experience/KeyImagery renders 1`] = `
   }
 }
 
-.emotion-403 {
+.emotion-379 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -801,7 +801,7 @@ exports[`Experience/KeyImagery renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-403 {
+  .emotion-379 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -818,7 +818,7 @@ exports[`Experience/KeyImagery renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-403 {
+  .emotion-379 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -830,39 +830,39 @@ exports[`Experience/KeyImagery renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-403 {
+  .emotion-379 {
     grid-template-columns: 1fr;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-403 {
+  .emotion-379 {
     grid-template-columns: 1fr;
   }
 }
 
 @media (min-width: 992px) {
-  .emotion-403 {
+  .emotion-379 {
     margin-top: 60px;
     margin-bottom: 60px;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-403 {
+  .emotion-379 {
     margin-top: 40px;
     margin-bottom: 40px;
   }
 }
 
 @media (max-width: 576px) {
-  .emotion-403 {
+  .emotion-379 {
     margin-top: 30px;
     margin-bottom: 30px;
   }
 }
 
-.emotion-404 {
+.emotion-380 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -880,7 +880,7 @@ exports[`Experience/KeyImagery renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-404 {
+  .emotion-380 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -895,7 +895,7 @@ exports[`Experience/KeyImagery renders 1`] = `
   }
 }
 
-.emotion-405 {
+.emotion-381 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -909,7 +909,7 @@ exports[`Experience/KeyImagery renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-405 {
+  .emotion-381 {
     -webkit-box-pack: center;
     -ms-flex-pack: center;
     -webkit-justify-content: center;
@@ -921,31 +921,31 @@ exports[`Experience/KeyImagery renders 1`] = `
   }
 }
 
-.emotion-406 {
+.emotion-382 {
   width: 20px;
   height: 20px;
   z-index: 10;
 }
 
 @media (max-width: 576px) {
-  .emotion-406 {
+  .emotion-382 {
     margin-bottom: 8px;
   }
 }
 
-.emotion-407 {
+.emotion-383 {
   margin-left: 10px;
   margin-right: 10px;
   z-index: 10;
 }
 
 @media (max-width: 576px) {
-  .emotion-407 {
+  .emotion-383 {
     display: none;
   }
 }
 
-.emotion-408 {
+.emotion-384 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -957,7 +957,7 @@ exports[`Experience/KeyImagery renders 1`] = `
   position: relative;
 }
 
-.emotion-409 {
+.emotion-385 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -984,7 +984,7 @@ exports[`Experience/KeyImagery renders 1`] = `
   animation-name: animation-0;
 }
 
-.emotion-410 {
+.emotion-386 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -1007,12 +1007,12 @@ exports[`Experience/KeyImagery renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-410 {
+  .emotion-386 {
     text-align: center;
   }
 }
 
-.emotion-411 {
+.emotion-387 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1037,7 +1037,7 @@ exports[`Experience/KeyImagery renders 1`] = `
   animation-name: animation-2;
 }
 
-.emotion-412 {
+.emotion-388 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -2145,19 +2145,16 @@ exports[`Experience/KeyImagery renders 1`] = `
                 Key Imagery
               </a>
             </div>
-            <div
-              className="emotion-44"
-            />
           </div>
         </div>
       </div>
     </div>
   </div>
   <div
-    className="emotion-92"
+    className="emotion-91"
   >
     <div
-      className="emotion-93"
+      className="emotion-92"
     >
       <div
         className="emotion-37"
@@ -2810,19 +2807,16 @@ exports[`Experience/KeyImagery renders 1`] = `
             Key Imagery
           </a>
         </div>
-        <div
-          className="emotion-44"
-        />
       </div>
     </div>
     <div
-      className="emotion-149"
+      className="emotion-147"
     >
       <div
-        className="emotion-150"
+        className="emotion-148"
       >
         <div
-          className="emotion-151"
+          className="emotion-149"
           id="overview"
         >
           <div
@@ -2928,7 +2922,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 }
               >
                 <a
-                  className="emotion-13 emotion-14 emotion-15 emotion-164"
+                  className="emotion-13 emotion-14 emotion-15 emotion-162"
                   href="/brand-policy"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -2952,7 +2946,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
           </div>
         </div>
         <div
-          className="emotion-151"
+          className="emotion-149"
           id="illustrations"
         >
           <div
@@ -2985,23 +2979,6 @@ Images have descriptions that act as guidelines for both accessibility and commu
               Illustrations
             </h2>
             <div
-              className="emotion-15"
-              dir="auto"
-              style={
-                Object {
-                  "color": "rgba(17,18,20,1.00)",
-                  "fontFamily": "EB Garamond, eb-garamond, Garamond, serif",
-                  "fontSize": "20px",
-                  "lineHeight": "28px",
-                  "marginLeft": "10px",
-                  "marginRight": "10px",
-                  "textRendering": "geometricPrecision",
-                }
-              }
-            >
-              Illustrations show concrete ways that humans interact with an idea. They utilize current mental models to simplify a concept.
-            </div>
-            <div
               className="emotion-11"
               style={
                 Object {
@@ -3032,7 +3009,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 }
               >
                 <div
-                  className="emotion-172"
+                  className="emotion-169"
                 >
                   <div
                     className="emotion-11"
@@ -3257,327 +3234,24 @@ Images have descriptions that act as guidelines for both accessibility and commu
             </div>
           </div>
         </div>
-        <div
-          className="emotion-151"
-          id="abstract-graphics"
-        >
-          <div
-            className="emotion-11"
-            style={
-              Object {
-                "marginTop": "100px",
-              }
-            }
-          >
-            <h2
-              aria-level="2"
-              className="emotion-13 emotion-15"
-              dir="auto"
-              role="heading"
-              style={
-                Object {
-                  "color": "rgba(17,18,20,1.00)",
-                  "fontFamily": "EB Garamond, eb-garamond, Garamond, serif",
-                  "fontSize": "28px",
-                  "lineHeight": "32px",
-                  "marginBottom": "20px",
-                  "marginLeft": "10px",
-                  "marginRight": "10px",
-                  "textRendering": "geometricPrecision",
-                  "textTransform": "none",
-                }
-              }
-            >
-              Abstract Graphics
-            </h2>
-            <div
-              className="emotion-15"
-              dir="auto"
-              style={
-                Object {
-                  "color": "rgba(17,18,20,1.00)",
-                  "fontFamily": "EB Garamond, eb-garamond, Garamond, serif",
-                  "fontSize": "20px",
-                  "lineHeight": "28px",
-                  "marginLeft": "10px",
-                  "marginRight": "10px",
-                  "textRendering": "geometricPrecision",
-                }
-              }
-            >
-              Abstract Graphics are visual tools that use coins to animate an idea. They can be dynamic or static.
-            </div>
-            <div
-              className="emotion-11"
-              style={
-                Object {
-                  "WebkitBoxDirection": "normal",
-                  "WebkitBoxLines": "multiple",
-                  "WebkitBoxOrient": "horizontal",
-                  "WebkitFlexDirection": "row",
-                  "WebkitFlexWrap": "wrap",
-                  "flexDirection": "row",
-                  "flexWrap": "wrap",
-                  "msFlexDirection": "row",
-                  "msFlexWrap": "wrap",
-                }
-              }
-            >
-              <div
-                className="emotion-11"
-                style={
-                  Object {
-                    "marginLeft": "10px",
-                    "marginRight": "10px",
-                    "marginTop": "20px",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div
-                  className="emotion-172"
-                >
-                  <div
-                    className="emotion-11"
-                  >
-                    <div
-                      className="emotion-11"
-                      style={
-                        Object {
-                          "marginBottom": "20px",
-                          "marginRight": "40px",
-                          "marginTop": "20px",
-                        }
-                      }
-                    >
-                      <div
-                        className="emotion-11"
-                        style={
-                          Object {
-                            "display": "block",
-                            "overflowX": "hidden",
-                            "overflowY": "hidden",
-                          }
-                        }
-                      >
-                        <div
-                          style={
-                            Object {
-                              "display": "block",
-                              "paddingBottom": "50%",
-                              "width": "100%",
-                            }
-                          }
-                        />
-                        <div
-                          style={
-                            Object {
-                              "bottom": "0px",
-                              "height": "100%",
-                              "left": "0px",
-                              "position": "absolute",
-                              "top": "0px",
-                              "width": "100%",
-                            }
-                          }
-                        >
-                          <div
-                            aria-label="Preview of Graphic"
-                            className="emotion-11"
-                            style={
-                              Object {
-                                "WebkitFlexBasis": "auto",
-                                "flexBasis": "auto",
-                                "height": "100%",
-                                "msFlexPreferredSize": "auto",
-                                "overflowX": "hidden",
-                                "overflowY": "hidden",
-                                "width": "100%",
-                                "zIndex": 0,
-                              }
-                            }
-                          >
-                            <div
-                              className="emotion-11"
-                              style={
-                                Object {
-                                  "backgroundColor": "rgba(0,0,0,0.00)",
-                                  "backgroundPosition": "center",
-                                  "backgroundRepeat": "no-repeat",
-                                  "backgroundSize": "contain",
-                                  "bottom": "0px",
-                                  "height": "100%",
-                                  "left": "0px",
-                                  "position": "absolute",
-                                  "right": "0px",
-                                  "top": "0px",
-                                  "width": "100%",
-                                  "zIndex": -1,
-                                }
-                              }
-                              suppressHydrationWarning={true}
-                            />
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      className="emotion-11"
-                      style={
-                        Object {
-                          "WebkitFlex": 1,
-                          "flex": 1,
-                          "msFlex": "1 1 0%",
-                        }
-                      }
-                    >
-                      <div
-                        className="emotion-15"
-                        dir="auto"
-                        style={
-                          Object {
-                            "color": "rgba(17,18,20,1.00)",
-                            "fontFamily": "Jost, futura-pt, futura, sans-serif",
-                            "fontSize": "16px",
-                            "fontWeight": "500",
-                            "lineHeight": "18px",
-                            "marginBottom": "5px",
-                            "marginTop": "5px",
-                            "textRendering": "geometricPrecision",
-                          }
-                        }
-                      >
-                        Graphic
-                      </div>
-                      <div
-                        className="emotion-15"
-                        dir="auto"
-                        style={
-                          Object {
-                            "color": "rgba(17,18,20,1.00)",
-                            "fontFamily": "EB Garamond, eb-garamond, Garamond, serif",
-                            "fontSize": "16px",
-                            "lineHeight": "20px",
-                            "textRendering": "geometricPrecision",
-                          }
-                        }
-                      >
-                        visual
-                      </div>
-                    </div>
-                    <div
-                      className="emotion-11"
-                      onClick={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseUp={[Function]}
-                    >
-                      <a
-                        className="emotion-13 emotion-14 emotion-15"
-                        dir="auto"
-                        href="/example.jpg"
-                        onClick={[Function]}
-                        onMouseEnter={[Function]}
-                        role="link"
-                        style={
-                          Object {
-                            "WebkitAlignItems": "center",
-                            "WebkitBoxAlign": "center",
-                            "WebkitBoxFlex": 0,
-                            "WebkitBoxPack": "start",
-                            "WebkitFlexGrow": 0,
-                            "WebkitJustifyContent": "flex-start",
-                            "alignItems": "center",
-                            "backgroundColor": "rgba(0,0,0,0.00)",
-                            "borderBottomColor": "rgba(0,0,0,0.00)",
-                            "borderLeftColor": "rgba(0,0,0,0.00)",
-                            "borderRightColor": "rgba(0,0,0,0.00)",
-                            "borderTopColor": "rgba(0,0,0,0.00)",
-                            "color": "rgba(53,208,127,1.00)",
-                            "cursor": "pointer",
-                            "display": "inline-flex",
-                            "flexGrow": 0,
-                            "fontFamily": "Jost, futura-pt, futura, sans-serif",
-                            "fontSize": "16px",
-                            "fontWeight": "500",
-                            "justifyContent": "flex-start",
-                            "lineHeight": "16px",
-                            "minWidth": "150px",
-                            "msFlexAlign": "center",
-                            "msFlexPack": "start",
-                            "msFlexPositive": 0,
-                            "opacity": 1,
-                            "outlineColor": "transparent",
-                            "paddingBottom": "10px",
-                            "paddingLeft": "0px",
-                            "paddingRight": "20px",
-                            "paddingTop": "10px",
-                            "textAlign": "center",
-                            "textRendering": "geometricPrecision",
-                            "width": "fit-content",
-                          }
-                        }
-                      >
-                        Download
-                        <div
-                          className="emotion-11"
-                          style={
-                            Object {
-                              "display": "inline-flex",
-                              "paddingLeft": "8px",
-                            }
-                          }
-                        >
-                          <svg
-                            fill="none"
-                            height={12}
-                            viewBox="0 0 10 13"
-                            width={12}
-                          >
-                            <path
-                              d="M0 12H10"
-                              stroke="#35D07F"
-                              strokeWidth="1.5"
-                            />
-                            <path
-                              d="M5 0V9"
-                              stroke="#35D07F"
-                              strokeWidth="1.5"
-                            />
-                            <path
-                              d="M1 5L5 9L9 5"
-                              stroke="#35D07F"
-                              strokeWidth="1.5"
-                            />
-                          </svg>
-                        </div>
-                      </a>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
       </div>
     </div>
   </div>
   <div
-    className="emotion-207"
+    className="emotion-183"
     id="experience-footer"
   >
     <section
-      className="emotion-208"
+      className="emotion-184"
     >
       <div
-        className="emotion-209"
+        className="emotion-185"
       >
         <div
-          className="emotion-210"
+          className="emotion-186"
         >
           <div
-            className="emotion-211"
+            className="emotion-187"
           >
             <svg
               fill="none"
@@ -3600,19 +3274,19 @@ Images have descriptions that act as guidelines for both accessibility and commu
             </svg>
           </div>
           <div
-            className="emotion-212"
+            className="emotion-188"
           >
             <p
-              className="emotion-213"
+              className="emotion-189"
             >
               Nothing herein constitutes an offer to sell, or the solicitation of an offer to buy, any securities or tokens.
             </p>
             <p
-              className="emotion-213"
+              className="emotion-189"
             >
               Read more in Celo 
               <a
-                className="emotion-215"
+                className="emotion-191"
                 href="/terms"
               >
                 Terms of Service
@@ -3621,21 +3295,21 @@ Images have descriptions that act as guidelines for both accessibility and commu
           </div>
         </div>
         <div
-          className="emotion-216"
+          className="emotion-192"
         >
           <div
-            className="emotion-217"
+            className="emotion-193"
           >
             <div
-              className="emotion-218"
+              className="emotion-194"
             >
               <h6
-                className="emotion-219"
+                className="emotion-195"
               >
                 Celo
               </h6>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -3684,7 +3358,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -3733,7 +3407,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -3782,7 +3456,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -3831,7 +3505,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -3880,7 +3554,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -3929,7 +3603,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -3978,7 +3652,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -4028,15 +3702,15 @@ Images have descriptions that act as guidelines for both accessibility and commu
               </div>
             </div>
             <div
-              className="emotion-260"
+              className="emotion-236"
             >
               <h6
-                className="emotion-219"
+                className="emotion-195"
               >
                 Technology
               </h6>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -4085,7 +3759,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -4134,7 +3808,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -4183,7 +3857,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -4232,7 +3906,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -4282,15 +3956,15 @@ Images have descriptions that act as guidelines for both accessibility and commu
               </div>
             </div>
             <div
-              className="emotion-260"
+              className="emotion-236"
             >
               <h6
-                className="emotion-219"
+                className="emotion-195"
               >
                 Resources
               </h6>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -4339,7 +4013,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -4388,7 +4062,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -4437,7 +4111,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -4486,7 +4160,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -4535,7 +4209,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -4584,7 +4258,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -4633,7 +4307,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -4682,7 +4356,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -4732,15 +4406,15 @@ Images have descriptions that act as guidelines for both accessibility and commu
               </div>
             </div>
             <div
-              className="emotion-334"
+              className="emotion-310"
             >
               <h6
-                className="emotion-219"
+                className="emotion-195"
               >
                 Social
               </h6>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -4813,7 +4487,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -4888,7 +4562,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -4961,7 +4635,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -5034,7 +4708,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -5109,7 +4783,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -5182,7 +4856,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -5254,7 +4928,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -5324,7 +4998,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -5394,7 +5068,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -5464,7 +5138,7 @@ Images have descriptions that act as guidelines for both accessibility and commu
                 </div>
               </div>
               <div
-                className="emotion-220"
+                className="emotion-196"
               >
                 <div
                   className="emotion-11"
@@ -5539,48 +5213,48 @@ Images have descriptions that act as guidelines for both accessibility and commu
       </div>
     </section>
     <section
-      className="emotion-208"
+      className="emotion-184"
     >
       <div
-        className="emotion-403"
+        className="emotion-379"
       >
         <div
-          className="emotion-404"
+          className="emotion-380"
         >
           <div
-            className="emotion-405"
+            className="emotion-381"
           >
             <img
-              className="emotion-406"
+              className="emotion-382"
               height={100}
               src="/image.png"
               width={100}
             />
             <span
-              className="emotion-407"
+              className="emotion-383"
             >
               |
             </span>
             <div
-              className="emotion-408"
+              className="emotion-384"
             >
               <div
-                className="emotion-409"
+                className="emotion-385"
               />
               <span
-                className="emotion-410"
+                className="emotion-386"
               >
                 "
                 Change the Story
                 "
               </span>
               <div
-                className="emotion-411"
+                className="emotion-387"
               />
             </div>
           </div>
           <small
-            className="emotion-412"
+            className="emotion-388"
           >
             The Celo Foundation, © Celo 2021
           </small>

--- a/src/_page-tests/experience/__snapshots__/logo.test.tsx.snap
+++ b/src/_page-tests/experience/__snapshots__/logo.test.tsx.snap
@@ -331,7 +331,7 @@ exports[`Experience/Logo renders 1`] = `
   transition-duration: 500ms;
 }
 
-.emotion-92 {
+.emotion-91 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -353,7 +353,7 @@ exports[`Experience/Logo renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-92 {
+  .emotion-91 {
     z-index: -5;
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
@@ -363,18 +363,18 @@ exports[`Experience/Logo renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-92 {
+  .emotion-91 {
     max-width: 958px;
   }
 }
 
 @media (min-width: 992px) {
-  .emotion-92 {
+  .emotion-91 {
     max-width: 1080px;
   }
 }
 
-.emotion-93 {
+.emotion-92 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -393,12 +393,12 @@ exports[`Experience/Logo renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-93 {
+  .emotion-92 {
     display: none;
   }
 }
 
-.emotion-149 {
+.emotion-147 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -411,7 +411,7 @@ exports[`Experience/Logo renders 1`] = `
 }
 
 @media (min-width: 576px) {
-  .emotion-149 {
+  .emotion-147 {
     -webkit-flex: 1;
     -ms-flex: 1;
     flex: 1;
@@ -422,7 +422,7 @@ exports[`Experience/Logo renders 1`] = `
   }
 }
 
-.emotion-150 {
+.emotion-148 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -436,7 +436,7 @@ exports[`Experience/Logo renders 1`] = `
 }
 
 @media (min-width: 576px) {
-  .emotion-150 {
+  .emotion-148 {
     -webkit-transform: translateY(-25);
     -moz-transform: translateY(-25);
     -ms-transform: translateY(-25);
@@ -444,7 +444,7 @@ exports[`Experience/Logo renders 1`] = `
   }
 }
 
-.emotion-151 {
+.emotion-149 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -455,7 +455,7 @@ exports[`Experience/Logo renders 1`] = `
   flex-direction: column;
 }
 
-.emotion-294 {
+.emotion-292 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -468,7 +468,7 @@ exports[`Experience/Logo renders 1`] = `
 }
 
 @media (min-width: 576px) {
-  .emotion-294 {
+  .emotion-292 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -479,7 +479,7 @@ exports[`Experience/Logo renders 1`] = `
   }
 }
 
-.emotion-295 {
+.emotion-293 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -494,14 +494,14 @@ exports[`Experience/Logo renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-295 {
+  .emotion-293 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
   }
 }
 
-.emotion-319 {
+.emotion-317 {
   margin-top: 20px;
   padding-top: 10px;
   padding-bottom: 10px;
@@ -510,17 +510,17 @@ exports[`Experience/Logo renders 1`] = `
   flex: 1;
 }
 
-.emotion-320 {
+.emotion-318 {
   margin: 5px 0px;
 }
 
-.emotion-349 {
+.emotion-347 {
   z-index: -10;
   background-color: #FFFFFF;
   margin-top: 50px;
 }
 
-.emotion-350 {
+.emotion-348 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -540,7 +540,7 @@ exports[`Experience/Logo renders 1`] = `
   width: 100%;
 }
 
-.emotion-351 {
+.emotion-349 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -569,7 +569,7 @@ exports[`Experience/Logo renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-351 {
+  .emotion-349 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -586,7 +586,7 @@ exports[`Experience/Logo renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-351 {
+  .emotion-349 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -598,36 +598,36 @@ exports[`Experience/Logo renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-351 {
+  .emotion-349 {
     grid-template-columns: 1fr 1fr 1fr;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-351 {
+  .emotion-349 {
     grid-template-columns: 1fr 1fr 1fr;
   }
 }
 
 @media (min-width: 992px) {
-  .emotion-351 {
+  .emotion-349 {
     margin-top: 60px;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-351 {
+  .emotion-349 {
     margin-top: 40px;
   }
 }
 
 @media (max-width: 576px) {
-  .emotion-351 {
+  .emotion-349 {
     margin-top: 30px;
   }
 }
 
-.emotion-352 {
+.emotion-350 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -640,12 +640,12 @@ exports[`Experience/Logo renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-352 {
+  .emotion-350 {
     grid-column: span 3;
   }
 }
 
-.emotion-353 {
+.emotion-351 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -658,7 +658,7 @@ exports[`Experience/Logo renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-353 {
+  .emotion-351 {
     margin-bottom: 30px;
     -webkit-box-pack: center;
     -ms-flex-pack: center;
@@ -671,7 +671,7 @@ exports[`Experience/Logo renders 1`] = `
   }
 }
 
-.emotion-354 {
+.emotion-352 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -684,7 +684,7 @@ exports[`Experience/Logo renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-354 {
+  .emotion-352 {
     -webkit-box-pack: center;
     -ms-flex-pack: center;
     -webkit-justify-content: center;
@@ -696,7 +696,7 @@ exports[`Experience/Logo renders 1`] = `
   }
 }
 
-.emotion-355 {
+.emotion-353 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -713,16 +713,16 @@ exports[`Experience/Logo renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-355 {
+  .emotion-353 {
     text-align: center;
   }
 }
 
-.emotion-357 {
+.emotion-355 {
   color: inherit;
 }
 
-.emotion-358 {
+.emotion-356 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -735,12 +735,12 @@ exports[`Experience/Logo renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-358 {
+  .emotion-356 {
     grid-column: span 3;
   }
 }
 
-.emotion-359 {
+.emotion-357 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -756,21 +756,21 @@ exports[`Experience/Logo renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-359 {
+  .emotion-357 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     justify-content: space-between;
   }
 }
 
-.emotion-360 {
+.emotion-358 {
   padding-left: 25px;
   padding-right: 25px;
   padding-start: 0;
 }
 
 @media (max-width: 576px) {
-  .emotion-360 {
+  .emotion-358 {
     margin-top: 35px;
     width: 50%;
     padding-left: 10px;
@@ -778,7 +778,7 @@ exports[`Experience/Logo renders 1`] = `
   }
 }
 
-.emotion-361 {
+.emotion-359 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -793,18 +793,18 @@ exports[`Experience/Logo renders 1`] = `
   margin-bottom: 20px;
 }
 
-.emotion-362 {
+.emotion-360 {
   margin-top: 8px;
   margin-bottom: 8px;
 }
 
-.emotion-402 {
+.emotion-400 {
   padding-left: 25px;
   padding-right: 25px;
 }
 
 @media (max-width: 576px) {
-  .emotion-402 {
+  .emotion-400 {
     margin-top: 35px;
     width: 50%;
     padding-left: 10px;
@@ -812,14 +812,14 @@ exports[`Experience/Logo renders 1`] = `
   }
 }
 
-.emotion-476 {
+.emotion-474 {
   padding-left: 25px;
   padding-right: 25px;
   padding-end: 0;
 }
 
 @media (max-width: 576px) {
-  .emotion-476 {
+  .emotion-474 {
     margin-top: 35px;
     width: 50%;
     padding-left: 10px;
@@ -827,7 +827,7 @@ exports[`Experience/Logo renders 1`] = `
   }
 }
 
-.emotion-545 {
+.emotion-543 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -856,7 +856,7 @@ exports[`Experience/Logo renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-545 {
+  .emotion-543 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -873,7 +873,7 @@ exports[`Experience/Logo renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-545 {
+  .emotion-543 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -885,39 +885,39 @@ exports[`Experience/Logo renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-545 {
+  .emotion-543 {
     grid-template-columns: 1fr;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-545 {
+  .emotion-543 {
     grid-template-columns: 1fr;
   }
 }
 
 @media (min-width: 992px) {
-  .emotion-545 {
+  .emotion-543 {
     margin-top: 60px;
     margin-bottom: 60px;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-545 {
+  .emotion-543 {
     margin-top: 40px;
     margin-bottom: 40px;
   }
 }
 
 @media (max-width: 576px) {
-  .emotion-545 {
+  .emotion-543 {
     margin-top: 30px;
     margin-bottom: 30px;
   }
 }
 
-.emotion-546 {
+.emotion-544 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -935,7 +935,7 @@ exports[`Experience/Logo renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-546 {
+  .emotion-544 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -950,7 +950,7 @@ exports[`Experience/Logo renders 1`] = `
   }
 }
 
-.emotion-547 {
+.emotion-545 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -964,7 +964,7 @@ exports[`Experience/Logo renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-547 {
+  .emotion-545 {
     -webkit-box-pack: center;
     -ms-flex-pack: center;
     -webkit-justify-content: center;
@@ -976,31 +976,31 @@ exports[`Experience/Logo renders 1`] = `
   }
 }
 
-.emotion-548 {
+.emotion-546 {
   width: 20px;
   height: 20px;
   z-index: 10;
 }
 
 @media (max-width: 576px) {
-  .emotion-548 {
+  .emotion-546 {
     margin-bottom: 8px;
   }
 }
 
-.emotion-549 {
+.emotion-547 {
   margin-left: 10px;
   margin-right: 10px;
   z-index: 10;
 }
 
 @media (max-width: 576px) {
-  .emotion-549 {
+  .emotion-547 {
     display: none;
   }
 }
 
-.emotion-550 {
+.emotion-548 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1012,7 +1012,7 @@ exports[`Experience/Logo renders 1`] = `
   position: relative;
 }
 
-.emotion-551 {
+.emotion-549 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1039,7 +1039,7 @@ exports[`Experience/Logo renders 1`] = `
   animation-name: animation-0;
 }
 
-.emotion-552 {
+.emotion-550 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -1062,12 +1062,12 @@ exports[`Experience/Logo renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-552 {
+  .emotion-550 {
     text-align: center;
   }
 }
 
-.emotion-553 {
+.emotion-551 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1092,7 +1092,7 @@ exports[`Experience/Logo renders 1`] = `
   animation-name: animation-2;
 }
 
-.emotion-554 {
+.emotion-552 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -2200,19 +2200,16 @@ exports[`Experience/Logo renders 1`] = `
                 Key Imagery
               </a>
             </div>
-            <div
-              className="emotion-44"
-            />
           </div>
         </div>
       </div>
     </div>
   </div>
   <div
-    className="emotion-92"
+    className="emotion-91"
   >
     <div
-      className="emotion-93"
+      className="emotion-92"
     >
       <div
         className="emotion-37"
@@ -2865,19 +2862,16 @@ exports[`Experience/Logo renders 1`] = `
             Key Imagery
           </a>
         </div>
-        <div
-          className="emotion-44"
-        />
       </div>
     </div>
     <div
-      className="emotion-149"
+      className="emotion-147"
     >
       <div
-        className="emotion-150"
+        className="emotion-148"
       >
         <div
-          className="emotion-151"
+          className="emotion-149"
           id="overview"
         >
           <div
@@ -4087,7 +4081,7 @@ Please use the full-color logo whenever possible.
           </div>
         </div>
         <div
-          className="emotion-151"
+          className="emotion-149"
           id="space-and-sizing"
         >
           <div
@@ -4534,7 +4528,7 @@ Please use the full-color logo whenever possible.
           </div>
         </div>
         <div
-          className="emotion-151"
+          className="emotion-149"
           id="backgrounds"
         >
           <div
@@ -5724,10 +5718,10 @@ Please use the full-color logo whenever possible.
               When it comes to applying the Celo brand to your own projects, the monochrome Celo logo works well on a variety of backgrounds. Use the dark logo on lighter backgrounds and the inverse logo on darker and more colorful backgrounds.
             </div>
             <div
-              className="emotion-294"
+              className="emotion-292"
             >
               <div
-                className="emotion-295"
+                className="emotion-293"
               >
                 <div
                   className="emotion-11"
@@ -5911,7 +5905,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-295"
+                className="emotion-293"
               >
                 <div
                   className="emotion-11"
@@ -6095,7 +6089,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-295"
+                className="emotion-293"
               >
                 <div
                   className="emotion-11"
@@ -6299,16 +6293,16 @@ Please use the full-color logo whenever possible.
               Do not overlay any of the logos of glyphs on top of images. Do not overlay the two-color logo ontop of unpreferred light colors.
             </div>
             <div
-              className="emotion-294"
+              className="emotion-292"
             >
               <div
-                className="emotion-295"
+                className="emotion-293"
               >
                 <div
-                  className="emotion-319"
+                  className="emotion-317"
                 >
                   <img
-                    className="emotion-320"
+                    className="emotion-318"
                     height={24}
                     src="/image.png"
                     width={24}
@@ -6430,10 +6424,10 @@ Please use the full-color logo whenever possible.
                   </div>
                 </div>
                 <div
-                  className="emotion-319"
+                  className="emotion-317"
                 >
                   <img
-                    className="emotion-320"
+                    className="emotion-318"
                     height={24}
                     src="/image.png"
                     width={24}
@@ -6556,13 +6550,13 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-295"
+                className="emotion-293"
               >
                 <div
-                  className="emotion-319"
+                  className="emotion-317"
                 >
                   <img
-                    className="emotion-320"
+                    className="emotion-318"
                     height={24}
                     src="/image.png"
                     width={24}
@@ -6644,10 +6638,10 @@ Please use the full-color logo whenever possible.
                   </div>
                 </div>
                 <div
-                  className="emotion-319"
+                  className="emotion-317"
                 >
                   <img
-                    className="emotion-320"
+                    className="emotion-318"
                     height={24}
                     src="/image.png"
                     width={24}
@@ -6730,13 +6724,13 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-295"
+                className="emotion-293"
               >
                 <div
-                  className="emotion-319"
+                  className="emotion-317"
                 >
                   <img
-                    className="emotion-320"
+                    className="emotion-318"
                     height={24}
                     src="/image.png"
                     width={24}
@@ -6818,10 +6812,10 @@ Please use the full-color logo whenever possible.
                   </div>
                 </div>
                 <div
-                  className="emotion-319"
+                  className="emotion-317"
                 >
                   <img
-                    className="emotion-320"
+                    className="emotion-318"
                     height={24}
                     src="/image.png"
                     width={24}
@@ -6910,20 +6904,20 @@ Please use the full-color logo whenever possible.
     </div>
   </div>
   <div
-    className="emotion-349"
+    className="emotion-347"
     id="experience-footer"
   >
     <section
-      className="emotion-350"
+      className="emotion-348"
     >
       <div
-        className="emotion-351"
+        className="emotion-349"
       >
         <div
-          className="emotion-352"
+          className="emotion-350"
         >
           <div
-            className="emotion-353"
+            className="emotion-351"
           >
             <svg
               fill="none"
@@ -6946,19 +6940,19 @@ Please use the full-color logo whenever possible.
             </svg>
           </div>
           <div
-            className="emotion-354"
+            className="emotion-352"
           >
             <p
-              className="emotion-355"
+              className="emotion-353"
             >
               Nothing herein constitutes an offer to sell, or the solicitation of an offer to buy, any securities or tokens.
             </p>
             <p
-              className="emotion-355"
+              className="emotion-353"
             >
               Read more in Celo 
               <a
-                className="emotion-357"
+                className="emotion-355"
                 href="/terms"
               >
                 Terms of Service
@@ -6967,21 +6961,21 @@ Please use the full-color logo whenever possible.
           </div>
         </div>
         <div
-          className="emotion-358"
+          className="emotion-356"
         >
           <div
-            className="emotion-359"
+            className="emotion-357"
           >
             <div
-              className="emotion-360"
+              className="emotion-358"
             >
               <h6
-                className="emotion-361"
+                className="emotion-359"
               >
                 Celo
               </h6>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -7030,7 +7024,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -7079,7 +7073,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -7128,7 +7122,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -7177,7 +7171,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -7226,7 +7220,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -7275,7 +7269,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -7324,7 +7318,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -7374,15 +7368,15 @@ Please use the full-color logo whenever possible.
               </div>
             </div>
             <div
-              className="emotion-402"
+              className="emotion-400"
             >
               <h6
-                className="emotion-361"
+                className="emotion-359"
               >
                 Technology
               </h6>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -7431,7 +7425,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -7480,7 +7474,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -7529,7 +7523,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -7578,7 +7572,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -7628,15 +7622,15 @@ Please use the full-color logo whenever possible.
               </div>
             </div>
             <div
-              className="emotion-402"
+              className="emotion-400"
             >
               <h6
-                className="emotion-361"
+                className="emotion-359"
               >
                 Resources
               </h6>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -7685,7 +7679,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -7734,7 +7728,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -7783,7 +7777,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -7832,7 +7826,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -7881,7 +7875,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -7930,7 +7924,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -7979,7 +7973,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -8028,7 +8022,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -8078,15 +8072,15 @@ Please use the full-color logo whenever possible.
               </div>
             </div>
             <div
-              className="emotion-476"
+              className="emotion-474"
             >
               <h6
-                className="emotion-361"
+                className="emotion-359"
               >
                 Social
               </h6>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -8159,7 +8153,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -8234,7 +8228,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -8307,7 +8301,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -8380,7 +8374,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -8455,7 +8449,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -8528,7 +8522,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -8600,7 +8594,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -8670,7 +8664,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -8740,7 +8734,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -8810,7 +8804,7 @@ Please use the full-color logo whenever possible.
                 </div>
               </div>
               <div
-                className="emotion-362"
+                className="emotion-360"
               >
                 <div
                   className="emotion-11"
@@ -8885,48 +8879,48 @@ Please use the full-color logo whenever possible.
       </div>
     </section>
     <section
-      className="emotion-350"
+      className="emotion-348"
     >
       <div
-        className="emotion-545"
+        className="emotion-543"
       >
         <div
-          className="emotion-546"
+          className="emotion-544"
         >
           <div
-            className="emotion-547"
+            className="emotion-545"
           >
             <img
-              className="emotion-548"
+              className="emotion-546"
               height={100}
               src="/image.png"
               width={100}
             />
             <span
-              className="emotion-549"
+              className="emotion-547"
             >
               |
             </span>
             <div
-              className="emotion-550"
+              className="emotion-548"
             >
               <div
-                className="emotion-551"
+                className="emotion-549"
               />
               <span
-                className="emotion-552"
+                className="emotion-550"
               >
                 "
                 Change the Story
                 "
               </span>
               <div
-                className="emotion-553"
+                className="emotion-551"
               />
             </div>
           </div>
           <small
-            className="emotion-554"
+            className="emotion-552"
           >
             The Celo Foundation, © Celo 2021
           </small>

--- a/src/_page-tests/experience/__snapshots__/typography.test.tsx.snap
+++ b/src/_page-tests/experience/__snapshots__/typography.test.tsx.snap
@@ -331,7 +331,7 @@ exports[`Experience/Typography renders 1`] = `
   transition-duration: 500ms;
 }
 
-.emotion-92 {
+.emotion-91 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -353,7 +353,7 @@ exports[`Experience/Typography renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-92 {
+  .emotion-91 {
     z-index: -5;
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
@@ -363,18 +363,18 @@ exports[`Experience/Typography renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-92 {
+  .emotion-91 {
     max-width: 958px;
   }
 }
 
 @media (min-width: 992px) {
-  .emotion-92 {
+  .emotion-91 {
     max-width: 1080px;
   }
 }
 
-.emotion-93 {
+.emotion-92 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -393,12 +393,12 @@ exports[`Experience/Typography renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-93 {
+  .emotion-92 {
     display: none;
   }
 }
 
-.emotion-149 {
+.emotion-147 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -411,7 +411,7 @@ exports[`Experience/Typography renders 1`] = `
 }
 
 @media (min-width: 576px) {
-  .emotion-149 {
+  .emotion-147 {
     -webkit-flex: 1;
     -ms-flex: 1;
     flex: 1;
@@ -422,7 +422,7 @@ exports[`Experience/Typography renders 1`] = `
   }
 }
 
-.emotion-150 {
+.emotion-148 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -436,7 +436,7 @@ exports[`Experience/Typography renders 1`] = `
 }
 
 @media (min-width: 576px) {
-  .emotion-150 {
+  .emotion-148 {
     -webkit-transform: translateY(-25);
     -moz-transform: translateY(-25);
     -ms-transform: translateY(-25);
@@ -444,7 +444,7 @@ exports[`Experience/Typography renders 1`] = `
   }
 }
 
-.emotion-151 {
+.emotion-149 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -455,13 +455,13 @@ exports[`Experience/Typography renders 1`] = `
   flex-direction: column;
 }
 
-.emotion-261 {
+.emotion-259 {
   z-index: -10;
   background-color: #FFFFFF;
   margin-top: 50px;
 }
 
-.emotion-262 {
+.emotion-260 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -481,7 +481,7 @@ exports[`Experience/Typography renders 1`] = `
   width: 100%;
 }
 
-.emotion-263 {
+.emotion-261 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -510,7 +510,7 @@ exports[`Experience/Typography renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-263 {
+  .emotion-261 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -527,7 +527,7 @@ exports[`Experience/Typography renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-263 {
+  .emotion-261 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -539,36 +539,36 @@ exports[`Experience/Typography renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-263 {
+  .emotion-261 {
     grid-template-columns: 1fr 1fr 1fr;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-263 {
+  .emotion-261 {
     grid-template-columns: 1fr 1fr 1fr;
   }
 }
 
 @media (min-width: 992px) {
-  .emotion-263 {
+  .emotion-261 {
     margin-top: 60px;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-263 {
+  .emotion-261 {
     margin-top: 40px;
   }
 }
 
 @media (max-width: 576px) {
-  .emotion-263 {
+  .emotion-261 {
     margin-top: 30px;
   }
 }
 
-.emotion-264 {
+.emotion-262 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -581,12 +581,12 @@ exports[`Experience/Typography renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-264 {
+  .emotion-262 {
     grid-column: span 3;
   }
 }
 
-.emotion-265 {
+.emotion-263 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -599,7 +599,7 @@ exports[`Experience/Typography renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-265 {
+  .emotion-263 {
     margin-bottom: 30px;
     -webkit-box-pack: center;
     -ms-flex-pack: center;
@@ -612,7 +612,7 @@ exports[`Experience/Typography renders 1`] = `
   }
 }
 
-.emotion-266 {
+.emotion-264 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -625,7 +625,7 @@ exports[`Experience/Typography renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-266 {
+  .emotion-264 {
     -webkit-box-pack: center;
     -ms-flex-pack: center;
     -webkit-justify-content: center;
@@ -637,7 +637,7 @@ exports[`Experience/Typography renders 1`] = `
   }
 }
 
-.emotion-267 {
+.emotion-265 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -654,16 +654,16 @@ exports[`Experience/Typography renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-267 {
+  .emotion-265 {
     text-align: center;
   }
 }
 
-.emotion-269 {
+.emotion-267 {
   color: inherit;
 }
 
-.emotion-270 {
+.emotion-268 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -676,12 +676,12 @@ exports[`Experience/Typography renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-270 {
+  .emotion-268 {
     grid-column: span 3;
   }
 }
 
-.emotion-271 {
+.emotion-269 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -697,21 +697,21 @@ exports[`Experience/Typography renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-271 {
+  .emotion-269 {
     -webkit-box-pack: justify;
     -webkit-justify-content: space-between;
     justify-content: space-between;
   }
 }
 
-.emotion-272 {
+.emotion-270 {
   padding-left: 25px;
   padding-right: 25px;
   padding-start: 0;
 }
 
 @media (max-width: 576px) {
-  .emotion-272 {
+  .emotion-270 {
     margin-top: 35px;
     width: 50%;
     padding-left: 10px;
@@ -719,7 +719,7 @@ exports[`Experience/Typography renders 1`] = `
   }
 }
 
-.emotion-273 {
+.emotion-271 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -734,18 +734,18 @@ exports[`Experience/Typography renders 1`] = `
   margin-bottom: 20px;
 }
 
-.emotion-274 {
+.emotion-272 {
   margin-top: 8px;
   margin-bottom: 8px;
 }
 
-.emotion-314 {
+.emotion-312 {
   padding-left: 25px;
   padding-right: 25px;
 }
 
 @media (max-width: 576px) {
-  .emotion-314 {
+  .emotion-312 {
     margin-top: 35px;
     width: 50%;
     padding-left: 10px;
@@ -753,14 +753,14 @@ exports[`Experience/Typography renders 1`] = `
   }
 }
 
-.emotion-388 {
+.emotion-386 {
   padding-left: 25px;
   padding-right: 25px;
   padding-end: 0;
 }
 
 @media (max-width: 576px) {
-  .emotion-388 {
+  .emotion-386 {
     margin-top: 35px;
     width: 50%;
     padding-left: 10px;
@@ -768,7 +768,7 @@ exports[`Experience/Typography renders 1`] = `
   }
 }
 
-.emotion-457 {
+.emotion-455 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -797,7 +797,7 @@ exports[`Experience/Typography renders 1`] = `
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-457 {
+  .emotion-455 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -814,7 +814,7 @@ exports[`Experience/Typography renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-457 {
+  .emotion-455 {
     display: grid;
     grid-auto-rows: auto;
     -webkit-align-self: center;
@@ -826,39 +826,39 @@ exports[`Experience/Typography renders 1`] = `
 }
 
 @media (min-width: 992px) {
-  .emotion-457 {
+  .emotion-455 {
     grid-template-columns: 1fr;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-457 {
+  .emotion-455 {
     grid-template-columns: 1fr;
   }
 }
 
 @media (min-width: 992px) {
-  .emotion-457 {
+  .emotion-455 {
     margin-top: 60px;
     margin-bottom: 60px;
   }
 }
 
 @media (min-width: 576px) and (max-width: 992px) {
-  .emotion-457 {
+  .emotion-455 {
     margin-top: 40px;
     margin-bottom: 40px;
   }
 }
 
 @media (max-width: 576px) {
-  .emotion-457 {
+  .emotion-455 {
     margin-top: 30px;
     margin-bottom: 30px;
   }
 }
 
-.emotion-458 {
+.emotion-456 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -876,7 +876,7 @@ exports[`Experience/Typography renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-458 {
+  .emotion-456 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -891,7 +891,7 @@ exports[`Experience/Typography renders 1`] = `
   }
 }
 
-.emotion-459 {
+.emotion-457 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -905,7 +905,7 @@ exports[`Experience/Typography renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-459 {
+  .emotion-457 {
     -webkit-box-pack: center;
     -ms-flex-pack: center;
     -webkit-justify-content: center;
@@ -917,31 +917,31 @@ exports[`Experience/Typography renders 1`] = `
   }
 }
 
-.emotion-460 {
+.emotion-458 {
   width: 20px;
   height: 20px;
   z-index: 10;
 }
 
 @media (max-width: 576px) {
-  .emotion-460 {
+  .emotion-458 {
     margin-bottom: 8px;
   }
 }
 
-.emotion-461 {
+.emotion-459 {
   margin-left: 10px;
   margin-right: 10px;
   z-index: 10;
 }
 
 @media (max-width: 576px) {
-  .emotion-461 {
+  .emotion-459 {
     display: none;
   }
 }
 
-.emotion-462 {
+.emotion-460 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -953,7 +953,7 @@ exports[`Experience/Typography renders 1`] = `
   position: relative;
 }
 
-.emotion-463 {
+.emotion-461 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -980,7 +980,7 @@ exports[`Experience/Typography renders 1`] = `
   animation-name: animation-0;
 }
 
-.emotion-464 {
+.emotion-462 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -1003,12 +1003,12 @@ exports[`Experience/Typography renders 1`] = `
 }
 
 @media (max-width: 576px) {
-  .emotion-464 {
+  .emotion-462 {
     text-align: center;
   }
 }
 
-.emotion-465 {
+.emotion-463 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1033,7 +1033,7 @@ exports[`Experience/Typography renders 1`] = `
   animation-name: animation-2;
 }
 
-.emotion-466 {
+.emotion-464 {
   font-weight: normal;
   margin: 0;
   margin-block-start: 0;
@@ -2141,19 +2141,16 @@ exports[`Experience/Typography renders 1`] = `
                 Key Imagery
               </a>
             </div>
-            <div
-              className="emotion-44"
-            />
           </div>
         </div>
       </div>
     </div>
   </div>
   <div
-    className="emotion-92"
+    className="emotion-91"
   >
     <div
-      className="emotion-93"
+      className="emotion-92"
     >
       <div
         className="emotion-37"
@@ -2806,19 +2803,16 @@ exports[`Experience/Typography renders 1`] = `
             Key Imagery
           </a>
         </div>
-        <div
-          className="emotion-44"
-        />
       </div>
     </div>
     <div
-      className="emotion-149"
+      className="emotion-147"
     >
       <div
-        className="emotion-150"
+        className="emotion-148"
       >
         <div
-          className="emotion-151"
+          className="emotion-149"
           id="overview"
         >
           <div
@@ -2929,7 +2923,7 @@ Refer to the
                   }
                 >
                   <a
-                    className="emotion-13 emotion-14 emotion-15 emotion-165"
+                    className="emotion-13 emotion-14 emotion-15 emotion-163"
                     href="https://medium.com/celoOrg/the-why-of-the-celo-coin-part-1-of-3-5e5701805847"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
@@ -3226,7 +3220,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
           </div>
         </div>
         <div
-          className="emotion-151"
+          className="emotion-149"
           id="type-scale"
         >
           <div
@@ -4487,20 +4481,20 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
     </div>
   </div>
   <div
-    className="emotion-261"
+    className="emotion-259"
     id="experience-footer"
   >
     <section
-      className="emotion-262"
+      className="emotion-260"
     >
       <div
-        className="emotion-263"
+        className="emotion-261"
       >
         <div
-          className="emotion-264"
+          className="emotion-262"
         >
           <div
-            className="emotion-265"
+            className="emotion-263"
           >
             <svg
               fill="none"
@@ -4523,19 +4517,19 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
             </svg>
           </div>
           <div
-            className="emotion-266"
+            className="emotion-264"
           >
             <p
-              className="emotion-267"
+              className="emotion-265"
             >
               Nothing herein constitutes an offer to sell, or the solicitation of an offer to buy, any securities or tokens.
             </p>
             <p
-              className="emotion-267"
+              className="emotion-265"
             >
               Read more in Celo 
               <a
-                className="emotion-269"
+                className="emotion-267"
                 href="/terms"
               >
                 Terms of Service
@@ -4544,21 +4538,21 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
           </div>
         </div>
         <div
-          className="emotion-270"
+          className="emotion-268"
         >
           <div
-            className="emotion-271"
+            className="emotion-269"
           >
             <div
-              className="emotion-272"
+              className="emotion-270"
             >
               <h6
-                className="emotion-273"
+                className="emotion-271"
               >
                 Celo
               </h6>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -4607,7 +4601,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -4656,7 +4650,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -4705,7 +4699,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -4754,7 +4748,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -4803,7 +4797,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -4852,7 +4846,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -4901,7 +4895,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -4951,15 +4945,15 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
               </div>
             </div>
             <div
-              className="emotion-314"
+              className="emotion-312"
             >
               <h6
-                className="emotion-273"
+                className="emotion-271"
               >
                 Technology
               </h6>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -5008,7 +5002,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -5057,7 +5051,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -5106,7 +5100,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -5155,7 +5149,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -5205,15 +5199,15 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
               </div>
             </div>
             <div
-              className="emotion-314"
+              className="emotion-312"
             >
               <h6
-                className="emotion-273"
+                className="emotion-271"
               >
                 Resources
               </h6>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -5262,7 +5256,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -5311,7 +5305,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -5360,7 +5354,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -5409,7 +5403,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -5458,7 +5452,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -5507,7 +5501,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -5556,7 +5550,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -5605,7 +5599,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -5655,15 +5649,15 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
               </div>
             </div>
             <div
-              className="emotion-388"
+              className="emotion-386"
             >
               <h6
-                className="emotion-273"
+                className="emotion-271"
               >
                 Social
               </h6>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -5736,7 +5730,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -5811,7 +5805,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -5884,7 +5878,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -5957,7 +5951,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -6032,7 +6026,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -6105,7 +6099,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -6177,7 +6171,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -6247,7 +6241,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -6317,7 +6311,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -6387,7 +6381,7 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
                 </div>
               </div>
               <div
-                className="emotion-274"
+                className="emotion-272"
               >
                 <div
                   className="emotion-11"
@@ -6462,48 +6456,48 @@ Use Jost* for call to actions, diagrams, instructions, and infographics.
       </div>
     </section>
     <section
-      className="emotion-262"
+      className="emotion-260"
     >
       <div
-        className="emotion-457"
+        className="emotion-455"
       >
         <div
-          className="emotion-458"
+          className="emotion-456"
         >
           <div
-            className="emotion-459"
+            className="emotion-457"
           >
             <img
-              className="emotion-460"
+              className="emotion-458"
               height={100}
               src="/image.png"
               width={100}
             />
             <span
-              className="emotion-461"
+              className="emotion-459"
             >
               |
             </span>
             <div
-              className="emotion-462"
+              className="emotion-460"
             >
               <div
-                className="emotion-463"
+                className="emotion-461"
               />
               <span
-                className="emotion-464"
+                className="emotion-462"
               >
                 "
                 Change the Story
                 "
               </span>
               <div
-                className="emotion-465"
+                className="emotion-463"
               />
             </div>
           </div>
           <small
-            className="emotion-466"
+            className="emotion-464"
           >
             The Celo Foundation, © Celo 2021
           </small>

--- a/src/_page-tests/experience/key-imagery.test.tsx
+++ b/src/_page-tests/experience/key-imagery.test.tsx
@@ -19,7 +19,7 @@ describe("Experience/KeyImagery", () => {
     const tree = renderer
       .create(
         <TestProvider>
-          <KeyImagery graphics={MOCK} illos={MOCK} />
+          <KeyImagery illos={MOCK} />
         </TestProvider>
       )
       .toJSON()

--- a/src/experience/brandkit/KeyImagery.tsx
+++ b/src/experience/brandkit/KeyImagery.tsx
@@ -41,7 +41,6 @@ const KeyImageryWrapped: NextPage<Props> = React.memo(function KeyImagery({
           id: brandImagery.illustrations,
           children: <Illustrations data={illos} />,
         },
-        { id: brandImagery.graphics, children: <AbstractGraphics data={graphics} /> },
       ]}
     />
   )
@@ -83,7 +82,6 @@ const Illustrations = React.memo(function _Illustrations({ data }: IlloProps) {
       <H2 style={[brandStyles.gap, standardStyles.elementalMarginBottom]}>
         {t("keyImagery.illoTitle")}
       </H2>
-      <Text style={[brandStyles.gap, fonts.p]}>{t("keyImagery.illoText")}</Text>
       <View style={[brandStyles.tiling, styles.illustrationsArea]}>
         {data &&
           data.map((illo) => (

--- a/src/experience/brandkit/KeyImagery.tsx
+++ b/src/experience/brandkit/KeyImagery.tsx
@@ -1,6 +1,6 @@
 import { NextPage } from "next"
 import * as React from "react"
-import { StyleSheet, Text, View } from "react-native"
+import { StyleSheet, View } from "react-native"
 import AssetProps from "src/../fullstack/AssetProps"
 import Page, { IMAGERY_PATH } from "src/experience/brandkit/common/Page"
 import { AssetTypes } from "src/experience/brandkit/tracking"
@@ -12,18 +12,16 @@ import { H2 } from "src/fonts/Fonts"
 import { NameSpaces, useTranslation } from "src/i18n"
 import { ScreenSizes, useScreenSize } from "src/layout/ScreenSize"
 import { hashNav } from "src/shared/menu-items"
-import { fonts, standardStyles } from "src/styles"
+import { standardStyles } from "src/styles"
 
 const { brandImagery } = hashNav
 
 interface Props {
   illos: AssetProps[]
-  graphics: AssetProps[]
 }
 
 const KeyImageryWrapped: NextPage<Props> = React.memo(function KeyImagery({
   illos,
-  graphics,
 }: Props) {
   const { t } = useTranslation(NameSpaces.brand)
 
@@ -95,38 +93,6 @@ const Illustrations = React.memo(function _Illustrations({ data }: IlloProps) {
               uri={illo.uri}
               loading={false}
               size={size}
-            />
-          ))}
-      </View>
-    </View>
-  )
-})
-
-interface GraphicsProps {
-  data: AssetProps[]
-}
-
-const AbstractGraphics = React.memo(function _AbstractGraphics({ data }: GraphicsProps) {
-  const { t } = useTranslation(NameSpaces.brand)
-  return (
-    <View style={standardStyles.sectionMarginTop}>
-      <H2 style={[brandStyles.gap, standardStyles.elementalMarginBottom]}>
-        {t("keyImagery.abstractTitle")}
-      </H2>
-      <Text style={[brandStyles.gap, fonts.p]}>{t("keyImagery.abstractText")}</Text>
-      <View style={brandStyles.tiling}>
-        {data &&
-          data.map((graphic) => (
-            <Showcase
-              key={graphic.id}
-              ratio={344 / 172}
-              assetType={AssetTypes.graphic}
-              description={graphic.description}
-              name={graphic.name}
-              preview={graphic.preview}
-              uri={graphic.uri}
-              loading={false}
-              size={"100%"}
             />
           ))}
       </View>

--- a/src/experience/brandkit/common/Page.tsx
+++ b/src/experience/brandkit/common/Page.tsx
@@ -74,12 +74,7 @@ const PAGES = [
   {
     title: "Key Imagery",
     href: IMAGERY_PATH,
-
-    sections: [
-      { title: "Overview", href: `${IMAGERY_PATH}#${hashNav.brandImagery.overview}` },
-      { title: "Illustrations", href: `${IMAGERY_PATH}#${hashNav.brandImagery.illustrations}` },
-      { title: "Abstract Graphics", href: `${IMAGERY_PATH}#${hashNav.brandImagery.graphics}` },
-    ],
+    sections: [],
   },
 ]
 


### PR DESCRIPTION
Most edits come from Airtable, we basically move assets into Illustrations from Abstract Graphics, as well as delete the subheaders in the nav. 