### PR TITLE
Add redirect to Valora's Supercharge T&C

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -152,11 +152,11 @@ function wwwRedirect(req: express.Request, res: express.Response, nextAction: ()
   })
 
   server.get("/celo-rewards-education", (_, res) => {
-    res.redirect("/save-terms-and-conditions")
+    res.redirect("https://valoraapp.com/supercharge-terms-and-conditions")
   })
 
   server.get("/celo-rewards", (_, res) => {
-    res.redirect("/save-terms-and-conditions")
+    res.redirect("https://valoraapp.com/supercharge-terms-and-conditions")
   })
 
   server.get("/save-terms-and-conditions", (_, res) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -159,6 +159,10 @@ function wwwRedirect(req: express.Request, res: express.Response, nextAction: ()
     res.redirect("/save-terms-and-conditions")
   })
 
+  server.get("/save-terms-and-conditions", (_, res) => {
+    res.redirect("https://valoraapp.com/supercharge-terms-and-conditions")
+  })
+
   server.get("/stake-off", (_, res) => {
     res.redirect("https://forum.celo.org/t/the-great-celo-stake-off-the-details/136")
   })


### PR DESCRIPTION
The Supercharge program has changed and is no longer funded by Community Funds, so we're moving (and updating) the T&C to Valora's website