### PR TITLE
redirected the site

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -163,6 +163,10 @@ function wwwRedirect(req: express.Request, res: express.Response, nextAction: ()
     res.redirect("https://forum.celo.org/t/the-great-celo-stake-off-the-details/136")
   })
 
+  server.get("/celo-connect2022", (_, res) => {
+    res.redirect("https://celoconnect.com/")
+  })
+
   // File serving for OpenPGP WKD https://gnupg.org/blog/20161027-hosting-a-web-key-directory.html
   // Content must be served on multiple paths, and cannot use a redirect.
   ;["/.well-known/openpgpkey/hu/:userId", "/.well-known/openpgpkey/:host/hu/:userId"].forEach(


### PR DESCRIPTION
**Description**

Redirected the link from "celo.org/celo-connect2022" to "celoconnect.com".

issue #587 