### PR TITLE
fix missing return statement

### DIFF
--- a/pages/api/ecosystem/[form].ts
+++ b/pages/api/ecosystem/[form].ts
@@ -16,6 +16,7 @@ async function post(req: NextApiRequest, res: NextApiResponse) {
       res.status(CREATED).json({ ok: true })
     }
   } catch (e) {
+    console.error(e)
     respondError(res, e)
   }
 }

--- a/server/addToCRM.ts
+++ b/server/addToCRM.ts
@@ -126,7 +126,10 @@ function CRMError(e) {
   }
 }
 
-async function batchCreateOrUpdate(hubSpotClient: hubspot.Client, contacts: HubSpotContact[]) {
+async function batchCreateOrUpdate(
+  hubSpotClient: hubspot.Client,
+  contacts: HubSpotContact[]
+): Promise<hubspot.contactsModels.SimplePublicObject[]> {
   const BatchReadInputSimplePublicObjectId = {
     properties: ["email"],
     idProperty: "email",
@@ -177,7 +180,7 @@ async function batchCreateOrUpdate(hubSpotClient: hubspot.Client, contacts: HubS
   if (results.length === 2) {
     return [...results[0].body.results, ...results[1].body.results]
   } else {
-    results[0].body.results
+    return results[0].body.results
   }
 }
 


### PR DESCRIPTION
A missing Return Statement was causing the form to error out (after it had submitted the contact to hubspot but not before linking it to company)


also lets log errors 